### PR TITLE
ci: move reusable workflows into `.github/workflows`

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,4 +1,4 @@
-name: "Format Check"
+name: "Reusable Format Checking Workflow"
 
 on:
   workflow_call:

--- a/.github/workflows/format-suggestions-on-pr.yml
+++ b/.github/workflows/format-suggestions-on-pr.yml
@@ -1,4 +1,4 @@
-name: "Format PR"
+name: "Reusable Format PR Workflow"
 
 on:
   workflow_call:


### PR DESCRIPTION
GitHub expects reusable workflows that are referenced to be housed in the top-level directory of the `.github/workflows` directory in a repository.
