### PR TITLE
ci: disable codecov for pull requests from forks to prevent CI failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: "Report Coverage with Codecov"
         uses: codecov/codecov-action@v4
-        if: "${{ inputs.coverage }}"
+        if: "${{ inputs.coverage && github.event.pull_request.head.repo.full_name == github.repository }}"
         with:
           file: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
Since Codecov now does tokenless uploads, it easily hits the GitHub rate limits, causing the codecov step, and by extension the CI itself, to spuriously fail.

```
error - 2024-05-14 13:57:26,203 -- Commit creating failed: {"detail":"Tokenless has reached GitHub rate limit. Please upload using a token: https://docs.codecov.com/docs/adding-the-codecov-token. Expected available in 379 seconds."}
```

This could be worked around by setting `fail_ci_if_error` to false as well. However, that is not a better solution for two reasons.
  1. The Codecov CI step can spend an indeterminate amount of time waiting waiting for the token to be available per GitHub's rate limit, causing unnecessarily long CI running times. Timing out this step isn't a better option either, since there is no deterministic amount of time that this step is guaranteed to always take.
  2. Disabling `fail_ci_if_error` would mean that whenever codecov does run (i.e., on `main`/`master`, etc), if coverage reporting failed then CI would not report it appropriately, leaving underlying issues undiagnosed.
