### PR TITLE
ci: set `--depwarn=yes` for tests and downstream CI

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -48,7 +48,7 @@ on:
         type: boolean
       julia-runtest-depwarn:
         description: "Value of the --depwarn flag while running Julia"
-        default: "error"
+        default: "yes"
         required: false
         type: string
       continue-on-error:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ on:
         type: string
       julia-runtest-depwarn:
         description: "Value of the --depwarn flag while running Julia"
-        default: "error"
+        default: "yes"
         required: false
         type: string
       continue-on-error:


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
