### PR TITLE
Improve reusability of github workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,8 +62,6 @@ on:
         required: false
         type: boolean
     secrets:
-      GITHUB_TOKEN:
-        required: true
       CODECOV_TOKEN:
         required: true
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,6 +61,11 @@ on:
         description: "Prevent the workflow run from failing if/when the job fails"
         required: false
         type: boolean
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      CODECOV_TOKEN:
+        required: true
 
 jobs:
   tests:


### PR DESCRIPTION
Hi there!

I am not sure if this is the right place to ask or suggest this, but for the [QuantumKitHub organization](https://github.com/QuantumKitHub), I recently started using a workflow based on the SCIML ones in my github actions. Really, I just wanted to have the exact same workflow for the tests.
I was hoping to just use the actions defined here, however that fails because the secrets have been defined implicitly, and the packages use the `secrets: inherit` setting to pass them on. This however only works for actions that are defined within the same organization.
While I was able to circumvent this issue by simply copy-pasting the actions into my own organization, there might be other people that want to have a similar setup. I did some digging, and from what I understand, if you explicitly declare the secrets that will be passed on, this works across organizations.

This PR features the exact changes I made to enable this. I find it a bit hard to add tests, but I have a PR that now uses this workflow without failing because of the secrets [here](https://github.com/QuantumKitHub/MPSKit.jl/actions/runs/11913457605).
