### PR TITLE
Always upload coverage if enabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: "Report Coverage with Codecov"
         uses: codecov/codecov-action@v5
-        if: "${{ inputs.coverage && github.event.pull_request.head.repo.full_name == github.repository }}"
+        if: "${{ inputs.coverage }}"
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
Coverage analysis is currently broken, seemingly throughout the SciML organization, see e.g. https://app.codecov.io/gh/SciML/LinearSolve.jl/commits, https://app.codecov.io/gh/SciML/RootedTrees.jl/commits, https://app.codecov.io/gh/SciML/OrdinaryDiffEq.jl/commits

The problem is that the condition in the upload step prevents any coverage data being uploaded for pushes to the default branch (in fact anything that's not a non-fork PR).

There were some initial quirks with codecov when they updated their CLI (and the GH action) last year, but in principle uploads for PRs from forks should work out of the box (as mentioned e.g. in their README). So I don't think it's necessary anymore to put any additional check in there.

Alternatively, it should be changed to something like

```yaml
if: "${{ inputs.coverage && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}"
```

But I think it's easier to just remove the check (users of the workflow could in principle also make `inputs.coverage` conditional on whether its from a fork or not etc.; with the current check it's not possible at all for them to allow uploads from PRs from forks).