### PR TITLE
Upgrade GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -57,14 +57,14 @@ jobs:
     continue-on-error: ${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: "Setup Julia ${{ inputs.julia-version }}"
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@v3
         with:
           version: "${{ inputs.julia-version }}"
 
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
         if: "${{ inputs.cache }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
@@ -84,7 +84,7 @@ jobs:
           directories: "${{ inputs.coverage-directories }}"
 
       - name: "Report Coverage with Codecov"
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: "${{ inputs.coverage }}"
         with:
           files: lcov.info

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -68,21 +68,21 @@ jobs:
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
     steps:
       - name: "Checkout ${{ github.repository }}"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: "Checkout Downstream ${{ inputs.owner }}/${{ inputs.repo }}"
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: "${{ inputs.owner }}/${{ inputs.repo }}"
           path: "downstream"
 
       - name: "Setup Julia ${{ inputs.julia-version }}"
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@v3
         with:
           version: "${{ inputs.julia-version }}"
           arch: "${{ inputs.julia-arch || runner.arch }}"
 
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
         if: "${{ inputs.cache }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
@@ -113,7 +113,7 @@ jobs:
 
       - name: "Report Coverage with Codecov"
         if: "${{ inputs.coverage }}"
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -49,9 +49,9 @@ jobs:
       formatted: "${{ steps.check-formatting.outputs.formatted }}"
       formatting-changes: "${{ steps.check-formatting.outputs.formatting-changes }}"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
-      - uses: julia-actions/setup-julia@v2
+      - uses: julia-actions/setup-julia@v3
         with:
           version: "${{ inputs.julia-version }}"
 

--- a/.github/workflows/format-suggestions-on-pr.yml
+++ b/.github/workflows/format-suggestions-on-pr.yml
@@ -46,7 +46,7 @@ jobs:
     if: ${{ failure() }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: "Apply formatting changes"
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,15 +68,15 @@ jobs:
     continue-on-error: ${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: "Setup Julia ${{ inputs.julia-version }}"
-        uses: julia-actions/setup-julia@v2
+        uses: julia-actions/setup-julia@v3
         with:
           version: "${{ inputs.julia-version }}"
           arch: "${{ inputs.julia-arch || runner.arch }}"
 
-      - uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
         if: "${{ inputs.cache }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
@@ -99,7 +99,7 @@ jobs:
           directories: "${{ inputs.coverage-directories }}"
 
       - name: "Report Coverage with Codecov"
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         if: "${{ inputs.coverage }}"
         with:
           files: lcov.info


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

Bumps the actions used by the reusable workflows to their current latest majors:

| Action | From | To |
|---|---|---|
| `actions/checkout` | v5 | **v6** |
| `julia-actions/setup-julia` | v2 | **v3** |
| `julia-actions/cache` | v2 | **v3** |
| `codecov/codecov-action` | v5 | **v6** |

`julia-actions/{julia-buildpkg,julia-runtest,julia-processcoverage}` and `reviewdog/action-suggester` are already on their latest majors (v1).

### Breaking-change review (all safe for these workflows)
All four bumps are primarily **Node 24** runtime updates and need no config changes here:
- **setup-julia v3**: the `version: min` semantics change and the new x86_64-on-Apple-Silicon error do **not** apply — these workflows use `version: "1"`/`"nightly"` and `arch: runner.arch`.
- **cache v3**: now also saves the cache when a job **fails** (override with `save-always: false`). Behavior change only.
- **codecov v6 / checkout v6**: pure Node 24 bumps.

### Caveat
The Node 24 runtime requires a reasonably current **self-hosted runner agent** for the `self-hosted: true` code path. Hosted runners are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)