### PR TITLE
Add Dependabot for the reusable-workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

### Why
The reusable workflows here are the single point of consumption for ~82 SciML repos pinned to `@v1`. Their action versions silently froze for ~6 months until the manual bump in #28/#30 — and the actions had drifted multiple majors behind (`checkout` v4→v6, `setup-julia` v1→v3, etc.). There's currently nothing keeping them current.

### What
Adds `.github/dependabot.yml` with the `github-actions` ecosystem, weekly, all updates grouped into one PR (`ci`-prefixed, `dependencies`-labeled). Dependabot scans `.github/workflows/` and proposes bumps for `checkout`, `setup-julia`, `cache`, the `julia-*` actions, `codecov`, and `reviewdog`.

Updates land on `master`; they reach the ~82 consumers via the `master → v1` promotion (which is why keeping that promotion clean — ideally via `v1.x.y` tags — is the natural companion follow-up).

### Optional hardening (not in this PR)
Pin actions to commit SHAs (`@<sha> # v6.0.0`); Dependabot maintains SHA pins too. Deferred to keep this change minimal and match the repo's current tag-pin convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)