### PR TITLE
Stop failing CI on Codecov upload errors

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -90,4 +90,3 @@ jobs:
           files: lcov.info
           flags: "docs"
           token: "${{ secrets.CODECOV_TOKEN }}"
-          fail_ci_if_error: true

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -117,4 +117,3 @@ jobs:
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"
-          fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,4 +104,3 @@ jobs:
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"
-          fail_ci_if_error: true


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

### Why
`tests.yml`, `downstream.yml`, and `documentation.yml` set `fail_ci_if_error: true` on the Codecov step. A Codecov upload/processing outage then fails the entire CI run — the exact failure mode from the talk ("when Codecov broke, all of SciML went red"). With `CODECOV_TOKEN` configured, uploads are reliable, so this guard is pure downside risk.

### What
Removes the `fail_ci_if_error: true` line from all three workflows. `codecov-action` defaults `fail_ci_if_error` to `false`, so a transient Codecov hiccup no longer red-lines CI across the ~82 `@v1` consumers. No new inputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)