### PR TITLE
Fix docs build failing when coverage is disabled

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ inputs.github-token || secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ inputs.documenter-key || secrets.DOCUMENTER_KEY }}
-        run: ${{ inputs.debug-documenter && 'JULIA_DEBUG="Documenter"' || '' }} julia --project=docs/ ${{ inputs.coverage && '--code-coverage=user' }} docs/make.jl
+        run: ${{ inputs.debug-documenter && 'JULIA_DEBUG="Documenter"' || '' }} julia --project=docs/ ${{ inputs.coverage && '--code-coverage=user' || '' }} docs/make.jl
 
       - uses: julia-actions/julia-processcoverage@v1
         if: "${{ inputs.coverage }}"


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

### Bug
`documentation.yml`'s build step interpolated:
```
${{ inputs.coverage && '--code-coverage=user' }}
```
When `coverage: false`, that GitHub expression evaluates to the boolean `false`, which renders as the literal string `false` and is passed to Julia as a bogus script argument:
```
ERROR: SystemError: opening file ".../SciMLLogging.jl/false": No such file or directory
```
The adjacent `debug-documenter` interpolation already guards with `|| ''`; the coverage one was missing it.

### Fix
Add `|| ''` so a disabled coverage flag renders as an empty string.

### How it surfaced
Latent because adopters use the default `coverage: true`. Caught by the centralized-workflow migration pilot (SciML/SciMLLogging.jl#73), whose docs build doesn't collect coverage → `coverage: false` → failure. This blocks faithful migration of any repo whose docs don't collect coverage, so it should land on `v1` before the rollout.

Verified: the 6 migrated `Tests` jobs and `runic` pass on #73; only the docs job hit this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)