### PR TITLE
Promote latest fixes to v1 (dependabot, codecov, docs)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -90,4 +90,3 @@ jobs:
           files: lcov.info
           flags: "docs"
           token: "${{ secrets.CODECOV_TOKEN }}"
-          fail_ci_if_error: true

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -76,7 +76,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ inputs.github-token || secrets.GITHUB_TOKEN }}
           DOCUMENTER_KEY: ${{ inputs.documenter-key || secrets.DOCUMENTER_KEY }}
-        run: ${{ inputs.debug-documenter && 'JULIA_DEBUG="Documenter"' || '' }} julia --project=docs/ ${{ inputs.coverage && '--code-coverage=user' }} docs/make.jl
+        run: ${{ inputs.debug-documenter && 'JULIA_DEBUG="Documenter"' || '' }} julia --project=docs/ ${{ inputs.coverage && '--code-coverage=user' || '' }} docs/make.jl
 
       - uses: julia-actions/julia-processcoverage@v1
         if: "${{ inputs.coverage }}"

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -117,4 +117,3 @@ jobs:
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"
-          fail_ci_if_error: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,4 +104,3 @@ jobs:
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"
-          fail_ci_if_error: true


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

Promotes the merged `master` fixes to the `@v1` release branch that ~82 repos consume, ahead of the centralized-workflow migration rollout:

- #33 — add Dependabot for the actions
- #34 — stop failing CI on Codecov upload errors
- #35 — fix docs build when `coverage: false`

#35 in particular must be on `v1` before the rollout: migrated docs callers that don't collect coverage would otherwise fail.

(Not a fast-forward because `v1` and `master` diverged via separate merge commits earlier in the day; the actual file delta is just the three changes above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)