### PR TITLE
Add reusable runic, downgrade, spellcheck, and benchmark workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,21 @@
+name: "Reusable Benchmarks Workflow"
+
+on:
+  workflow_call:
+    inputs:
+      julia-version:
+        description: "Julia version"
+        default: "1"
+        required: false
+        type: string
+
+jobs:
+  benchmark:
+    name: "Benchmarks"
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: "${{ inputs.julia-version }}"

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -1,0 +1,64 @@
+name: "Reusable Downgrade Compatibility Test Workflow"
+
+on:
+  workflow_call:
+    inputs:
+      julia-version:
+        description: "Julia version (downgrade is usually run on the oldest supported version)"
+        default: "lts"
+        required: false
+        type: string
+      group:
+        description: "The 'GROUP' of tests that need to be run. This requires an ENV `GROUP` to be (conditionally) defined within your package tests as well to selectively run groups of tests"
+        default: ""
+        required: false
+        type: string
+      skip:
+        description: "Comma-separated list of packages to skip when downgrading compat (passed to julia-actions/julia-downgrade-compat)"
+        default: "Pkg,TOML"
+        required: false
+        type: string
+      projects:
+        description: "Comma-separated list of project directories to downgrade (passed to julia-actions/julia-downgrade-compat)"
+        default: "."
+        required: false
+        type: string
+      allow-reresolve:
+        description: "Allow Pkg to re-resolve (and thus relax) the downgraded environment when running tests"
+        default: false
+        required: false
+        type: boolean
+      self-hosted:
+        description: "Run the job on a self hosted machine"
+        default: false
+        required: false
+        type: boolean
+      os:
+        description: "The machine configuration on which the job needs to be run"
+        default: "ubuntu-latest"
+        required: false
+        type: string
+
+jobs:
+  downgrade:
+    name: "Downgrade Tests${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
+    runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "${{ inputs.julia-version }}"
+
+      - uses: julia-actions/julia-downgrade-compat@v2
+        with:
+          skip: "${{ inputs.skip }}"
+          projects: "${{ inputs.projects }}"
+
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          allow_reresolve: "${{ inputs.allow-reresolve }}"
+        env:
+          GROUP: "${{ inputs.group }}"

--- a/.github/workflows/runic.yml
+++ b/.github/workflows/runic.yml
@@ -1,0 +1,30 @@
+name: "Reusable Runic Formatting Check Workflow"
+
+on:
+  workflow_call:
+    inputs:
+      julia-version:
+        description: "Julia version"
+        default: "1"
+        required: false
+        type: string
+      runic-version:
+        description: "Version of Runic to use"
+        default: "1"
+        required: false
+        type: string
+
+jobs:
+  runic:
+    name: "Runic Format Check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "${{ inputs.julia-version }}"
+
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: "${{ inputs.runic-version }}"

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,15 @@
+name: "Reusable Spell Check Workflow"
+
+on:
+  workflow_call:
+
+jobs:
+  typos-check:
+    name: "Spell Check with Typos"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Actions Repository"
+        uses: actions/checkout@v6
+
+      - name: "Check spelling"
+        uses: crate-ci/typos@v1.47.0


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

### Why
A survey of all 143 Julia repos in SciML found four widely-used CI jobs still copy-pasted per repo instead of centralized:

| Job | Repos using it | Status |
|---|---|---|
| **Runic** format check | **134** | bespoke everywhere; the existing JuliaFormatter `format-check.yml` has only 2 users left (FastAlmostBandedMatrices, PureUMFPACK) |
| **Downgrade** CI | **101** | bespoke (the talk's "downgrade CI coming up" item) |
| **Spell check** (typos) | **111** | bespoke `SpellCheck.yml` |
| **Benchmarks** (AirspeedVelocity) | **5** | bespoke; heavyweight repos (ODE, MTK, BVP, …) |

### What
Four reusable (`workflow_call`) workflows, modeled on the proven bespoke versions so repos can collapse them to one-line callers:

- `runic.yml` → `fredrikekre/runic-action@v1` (inputs: `julia-version`, `runic-version`)
- `downgrade.yml` → `julia-actions/julia-downgrade-compat@v2` + buildpkg + runtest (inputs: `julia-version` [default `lts`], `group`, `skip`, `projects`, `allow-reresolve`, `os`, `self-hosted`)
- `spellcheck.yml` → `crate-ci/typos@v1.47.0` (Dependabot will keep the pin current)
- `benchmark.yml` → `MilesCranmer/AirspeedVelocity.jl@action-v1` (input: `julia-version`; `pull-requests: write`)

Additive — no effect on existing consumers. These feed the package-migration rollout: each repo's bespoke Runic/Downgrade/SpellCheck/benchmark workflows become one-line `@v1` callers.

Follow-up once merged + promoted to `v1`: I'll verify each on the pilot (the way `tests.yml` was) and, for `runic`, point the migration at it so the 134 Runic repos can standardize — and likely deprecate the orphaned JuliaFormatter `format-check.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)