### PR TITLE
Promote reusable runic/downgrade/spellcheck/benchmark workflows to v1

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,21 @@
+name: "Reusable Benchmarks Workflow"
+
+on:
+  workflow_call:
+    inputs:
+      julia-version:
+        description: "Julia version"
+        default: "1"
+        required: false
+        type: string
+
+jobs:
+  benchmark:
+    name: "Benchmarks"
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: MilesCranmer/AirspeedVelocity.jl@action-v1
+        with:
+          julia-version: "${{ inputs.julia-version }}"

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -1,0 +1,64 @@
+name: "Reusable Downgrade Compatibility Test Workflow"
+
+on:
+  workflow_call:
+    inputs:
+      julia-version:
+        description: "Julia version (downgrade is usually run on the oldest supported version)"
+        default: "lts"
+        required: false
+        type: string
+      group:
+        description: "The 'GROUP' of tests that need to be run. This requires an ENV `GROUP` to be (conditionally) defined within your package tests as well to selectively run groups of tests"
+        default: ""
+        required: false
+        type: string
+      skip:
+        description: "Comma-separated list of packages to skip when downgrading compat (passed to julia-actions/julia-downgrade-compat)"
+        default: "Pkg,TOML"
+        required: false
+        type: string
+      projects:
+        description: "Comma-separated list of project directories to downgrade (passed to julia-actions/julia-downgrade-compat)"
+        default: "."
+        required: false
+        type: string
+      allow-reresolve:
+        description: "Allow Pkg to re-resolve (and thus relax) the downgraded environment when running tests"
+        default: false
+        required: false
+        type: boolean
+      self-hosted:
+        description: "Run the job on a self hosted machine"
+        default: false
+        required: false
+        type: boolean
+      os:
+        description: "The machine configuration on which the job needs to be run"
+        default: "ubuntu-latest"
+        required: false
+        type: string
+
+jobs:
+  downgrade:
+    name: "Downgrade Tests${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
+    runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "${{ inputs.julia-version }}"
+
+      - uses: julia-actions/julia-downgrade-compat@v2
+        with:
+          skip: "${{ inputs.skip }}"
+          projects: "${{ inputs.projects }}"
+
+      - uses: julia-actions/julia-buildpkg@v1
+
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          allow_reresolve: "${{ inputs.allow-reresolve }}"
+        env:
+          GROUP: "${{ inputs.group }}"

--- a/.github/workflows/runic.yml
+++ b/.github/workflows/runic.yml
@@ -1,0 +1,30 @@
+name: "Reusable Runic Formatting Check Workflow"
+
+on:
+  workflow_call:
+    inputs:
+      julia-version:
+        description: "Julia version"
+        default: "1"
+        required: false
+        type: string
+      runic-version:
+        description: "Version of Runic to use"
+        default: "1"
+        required: false
+        type: string
+
+jobs:
+  runic:
+    name: "Runic Format Check"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "${{ inputs.julia-version }}"
+
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: "${{ inputs.runic-version }}"

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,15 @@
+name: "Reusable Spell Check Workflow"
+
+on:
+  workflow_call:
+
+jobs:
+  typos-check:
+    name: "Spell Check with Typos"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Actions Repository"
+        uses: actions/checkout@v6
+
+      - name: "Check spelling"
+        uses: crate-ci/typos@v1.47.0


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Opened as a draft.

Promotes the four new reusable workflows from #37 to the `@v1` release branch so consumers can call them:

- `runic.yml`
- `downgrade.yml`
- `spellcheck.yml`
- `benchmark.yml`

`v1` already has the earlier fixes (#33/#34/#35 via #36), so the delta here is just these four additions. Additive — no change to existing `@v1` consumers.

Once merged, I'll verify each by calling it from the pilot (SciMLLogging.jl) before wiring them into the package-migration rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)