### PR TITLE
runic.yml: add optional exclude input for unparseable/legacy files

### DIFF
--- a/.github/workflows/runic.yml
+++ b/.github/workflows/runic.yml
@@ -13,6 +13,11 @@ on:
         default: "1"
         required: false
         type: string
+      exclude:
+        description: "Space-separated list of paths/directories to exclude from the Runic check (e.g. for vendored or legacy files Runic cannot parse). They are dropped from the git index before the check so runic-action's `git ls-files` skips them; the working tree and history are untouched."
+        default: ""
+        required: false
+        type: string
 
 jobs:
   runic:
@@ -24,6 +29,10 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: "${{ inputs.julia-version }}"
+
+      - name: "Exclude paths from the Runic check"
+        if: "${{ inputs.exclude != '' }}"
+        run: git rm -r --cached --quiet --ignore-unmatch ${{ inputs.exclude }}
 
       - uses: fredrikekre/runic-action@v1
         with:


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Draft.

The reusable Runic check runs `runic-action` over every tracked `.jl` (`git ls-files '*.jl'`) with no way to skip files. Repos with legacy/vendored Julia that Runic can't parse (pre-1.0 syntax) then fail the whole check — surfaced by the rollout on **BlackBoxOptim.jl** (43 `spikes/` files Runic cannot parse).

Adds an `exclude` input (space-separated paths/dirs, default empty = whole repo, unchanged). When set, those paths are `git rm --cached`'d before the action runs so its `git ls-files` skips them — working tree and history untouched.

Follow-ups once this is on `v1`: BlackBoxOptim.jl's `FormatCheck.yml` sets `exclude: "spikes"` (and the one bad example) so its Runic check goes green; or the maintainer deletes the dead `spikes/` code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)