### PR TITLE
Add reusable sublibrary CI + downgrade workflows (monorepo support)

### DIFF
--- a/.github/workflows/sublibrary-downgrade.yml
+++ b/.github/workflows/sublibrary-downgrade.yml
@@ -1,0 +1,104 @@
+name: "Reusable Sublibrary Downgrade Workflow"
+
+# Runs downgrade-compat tests for each sublibrary under lib/*. The sublibrary
+# list is discovered automatically (every lib/<name> with a Project.toml),
+# minus any names in `exclude`.
+
+on:
+  workflow_call:
+    inputs:
+      julia-version:
+        description: "Julia version to run the downgrade tests on"
+        default: "lts"
+        required: false
+        type: string
+      skip:
+        description: "Comma-separated deps to skip when downgrading (passed to julia-downgrade-compat)"
+        default: "Pkg,TOML"
+        required: false
+        type: string
+      projects:
+        description: "Space-separated explicit list of lib/* sublibrary paths to downgrade-test. If empty, every lib/<name> with a Project.toml is used (minus `exclude`)."
+        default: ""
+        required: false
+        type: string
+      exclude:
+        description: "Space-separated lib/* sublibrary directory names to exclude (applies only when `projects` is empty / auto-discovery)"
+        default: ""
+        required: false
+        type: string
+      allow-reresolve:
+        description: "Allow the test environment to resolve transitive/test-only deps the downgrade step does not lock"
+        default: true
+        required: false
+        type: boolean
+      group-env-name:
+        description: "Optional env var name to set as the test group for each sublibrary (e.g. ODEDIFFEQ_TEST_GROUP)"
+        default: ""
+        required: false
+        type: string
+      group-env-value:
+        description: "Value for group-env-name, when set"
+        default: ""
+        required: false
+        type: string
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.list.outputs.projects }}
+      has_any: ${{ steps.list.outputs.has_any }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: "List lib/* sublibraries with a Project.toml (minus exclude)"
+        id: list
+        run: |
+          EXPLICIT="${{ inputs.projects }}"
+          EXCLUDE="${{ inputs.exclude }}"
+          projects=()
+          if [ -n "$EXPLICIT" ]; then
+            for p in $EXPLICIT; do projects+=("$p"); done
+          else
+            for d in lib/*/; do
+              d="${d%/}"
+              [ -f "$d/Project.toml" ] || continue
+              name="$(basename "$d")"
+              skipit=false
+              for ex in $EXCLUDE; do [ "$ex" = "$name" ] && skipit=true; done
+              $skipit || projects+=("$d")
+            done
+          fi
+          json=$(printf '%s\n' "${projects[@]}" | grep . | python3 -c 'import sys,json; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
+          echo "Sublibraries: $json"
+          echo "projects=$json" >> "$GITHUB_OUTPUT"
+          [ "$json" = "[]" ] && echo "has_any=false" >> "$GITHUB_OUTPUT" || echo "has_any=true" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: discover
+    if: needs.discover.outputs.has_any == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJson(needs.discover.outputs.projects) }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ inputs.julia-version }}
+      - name: "Set sublibrary test group"
+        if: "${{ inputs.group-env-name != '' }}"
+        run: echo "${{ inputs.group-env-name }}=${{ inputs.group-env-value }}" >> "$GITHUB_ENV"
+      - uses: julia-actions/julia-downgrade-compat@v2
+        with:
+          projects: ${{ matrix.project }}
+          skip: ${{ inputs.skip }}
+          julia_version: ${{ inputs.julia-version }}
+      - uses: julia-actions/julia-buildpkg@v1
+        with:
+          project: ${{ matrix.project }}
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          project: ${{ matrix.project }}
+          allow_reresolve: ${{ inputs.allow-reresolve }}

--- a/.github/workflows/sublibrary-tests.yml
+++ b/.github/workflows/sublibrary-tests.yml
@@ -1,0 +1,138 @@
+name: "Reusable Sublibrary CI Workflow"
+
+# Runs the test suite of each sublibrary under lib/* that is affected by the
+# changes in a push/PR, using the shared dependency-graph change detection in
+# SciML/.github. Per-sublibrary test config (groups, versions, runner, timeout,
+# threads) is read from lib/<sublibrary>/test/test_groups.toml; see
+# scripts/compute_affected_sublibraries.jl for the format and defaults.
+
+on:
+  workflow_call:
+    inputs:
+      dotgithub-ref:
+        description: "Ref of SciML/.github to source the affected-sublibrary detection script from"
+        default: "v1"
+        required: false
+        type: string
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      # JSON array of {group, version, runner, timeout, num_threads} objects for matrix include
+      matrix: ${{ steps.compute.outputs.matrix }}
+      has_changes: ${{ steps.compute.outputs.has_changes }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: "Checkout SciML/.github for the detection script"
+        uses: actions/checkout@v6
+        with:
+          repository: SciML/.github
+          ref: "${{ inputs.dotgithub-ref }}"
+          path: .sciml-dotgithub
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: '1'
+      - name: "Compute affected sublibraries from dependency graph"
+        id: compute
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+          else
+            git fetch origin ${{ github.event.pull_request.base.ref }}
+            CHANGED=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD)
+          fi
+
+          MATRIX=$(echo "$CHANGED" | julia .sciml-dotgithub/scripts/compute_affected_sublibraries.jl .)
+
+          echo "Changed files in lib/:"
+          echo "$CHANGED" | grep "^lib/" || echo "(none)"
+          echo ""
+          echo "Matrix entries: $MATRIX"
+
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          if [ "$MATRIX" = "[]" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  test:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.has_changes == 'true'
+    permissions:
+      actions: write
+      contents: read
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ matrix.timeout }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.detect-changes.outputs.matrix) }}
+    env:
+      # Pin the depot so the registry refresh below and the subsequent
+      # julia-actions steps all read/write the same depot on self-hosted
+      # runners (which may otherwise inject a per-runner depot for some steps
+      # but not others, hiding the freshly-added General registry from later
+      # resolves -> "expected package X to be registered" failures).
+      JULIA_DEPOT_PATH: ~/.julia
+    steps:
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: ${{ matrix.version }}
+      # Only write the cache from master pushes to avoid the Azure SAS auth
+      # failure storm during PR matrix uploads. The dynamic matrix shape makes
+      # a restore-only PR key impractical, so PRs skip the cache; this workflow
+      # only fires on lib/ changes so the lost PR cache hit is small.
+      - name: "Cache Julia depot (push only)"
+        if: github.event_name == 'push'
+        uses: julia-actions/cache@v3
+        continue-on-error: true
+        with:
+          cache-compiled: 'false'
+      - name: "Refresh General registry directly from git"
+        shell: julia --color=yes --project=. {0}
+        run: |
+          using Pkg
+          # Force a fresh git clone of General to dodge pkg-server lag, BEFORE
+          # the develop step: develop's resolve needs current versions of
+          # registered deps, and the cached pkg-server registry is often stale.
+          try
+              Pkg.Registry.rm("General")
+          catch
+          end
+          Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
+      - name: "Develop local path deps (Julia < 1.11)"
+        shell: julia --color=yes --project=. {0}
+        run: |
+          using Pkg
+          if VERSION < v"1.11.0-DEV.0"
+            toml = Pkg.TOML.parsefile("Project.toml")
+            if haskey(toml, "sources")
+              specs = Pkg.PackageSpec[]
+              for (dep, spec) in toml["sources"]
+                if spec isa Dict && haskey(spec, "path") && isdir(spec["path"])
+                  @info "Developing" dep spec["path"]
+                  push!(specs, Pkg.PackageSpec(path=spec["path"]))
+                end
+              end
+              isempty(specs) || Pkg.develop(specs)
+            end
+          end
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
+        with:
+          coverage: false
+          check_bounds: auto
+        env:
+          GROUP: ${{ matrix.group }}
+          JULIA_NUM_THREADS: ${{ matrix.num_threads }}
+      - uses: julia-actions/julia-processcoverage@v1
+      - uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          disable_safe_directory: true

--- a/scripts/compute_affected_sublibraries.jl
+++ b/scripts/compute_affected_sublibraries.jl
@@ -1,0 +1,279 @@
+#!/usr/bin/env julia
+#
+# Compute which sublibrary test jobs need to run based on changed files.
+#
+# Reads the dependency graph from lib/*/Project.toml [deps] section only
+# (NOT [extras]/test deps), identifies internal dependencies by matching dep names against
+# known sublibrary directory names, computes the transitive reverse-dependency
+# map, then given a list of changed files outputs a GitHub Actions matrix
+# include list as JSON.
+#
+# Each sublibrary can optionally define test groups in test/test_groups.toml:
+#
+#   [Core]
+#   versions = ["lts", "1.11", "1", "pre"]
+#
+#   [QA]
+#   versions = ["1"]
+#
+#   [GPU]
+#   versions = ["1"]
+#   runner = ["self-hosted", "Linux", "X64", "gpu"]
+#
+# Optional fields per group:
+#   runner      — string or array of labels (default: "ubuntu-latest")
+#   timeout     — integer, job timeout in minutes (default: 120)
+#   num_threads — integer, JULIA_NUM_THREADS (default: 1)
+#   local_only  — boolean (default: false). When true, the group is skipped
+#                 whenever this sublibrary is only being tested because an
+#                 upstream dependency changed (i.e. it landed in the matrix
+#                 transitively, not because its own files were touched). Use
+#                 this for groups so expensive that running them on every
+#                 dependency-graph rebuild is wasteful — e.g. weak-convergence
+#                 tests in the StochasticDiffEq sublibraries. The group still
+#                 runs whenever any file under lib/<this-pkg>/ is edited.
+#
+# If no test/test_groups.toml exists, the default is:
+#   Core on ["lts", "1.11", "1", "pre"]
+#   QA on ["1"]
+#
+# A group that needs test-only deps beyond the sublibrary's [targets].test list should
+# carry an isolated environment at test/<group>/Project.toml that runtests.jl activates
+# before running that group. This keeps heavy tooling (JET, Aqua, AllocCheck, CUDA, MTK, …)
+# out of the main test env and out of reverse-dependency resolution. See CONTRIBUTING.md
+# ("Per-group test environments") for the standard pattern.
+#
+# Directly changed packages get their full version matrix.
+# Transitively affected packages (reverse deps) only run on version "1".
+#
+# Usage:
+#   git diff --name-only origin/master...HEAD | julia compute_affected_sublibraries.jl /path/to/repo
+#
+# Output: JSON array of {group, version, runner, timeout, num_threads} objects
+#   for GitHub Actions matrix include.
+
+using TOML
+
+const DEFAULT_TEST_GROUPS = Dict(
+    "Core" => ["lts", "1.11", "1", "pre"],
+    "QA" => ["1"],
+)
+
+function build_dependency_graph(lib_dir::String)
+    # Collect all sublibrary names (directories with a Project.toml)
+    known_sublibs = Set{String}()
+    for entry in readdir(lib_dir)
+        if isfile(joinpath(lib_dir, entry, "Project.toml"))
+            push!(known_sublibs, entry)
+        end
+    end
+
+    # Parse each sublibrary's Project.toml for internal deps.
+    # Only use [deps], NOT [extras]/[targets] — those are test-only dependencies
+    # and should not propagate downstream test triggering.
+    graph = Dict{String, Vector{String}}()
+    for pkg in known_sublibs
+        toml = TOML.parsefile(joinpath(lib_dir, pkg, "Project.toml"))
+        internal_deps = String[]
+        if haskey(toml, "deps")
+            for dep_name in keys(toml["deps"])
+                if dep_name in known_sublibs
+                    push!(internal_deps, dep_name)
+                end
+            end
+        end
+        graph[pkg] = internal_deps
+    end
+
+    return graph
+end
+
+function compute_reverse_deps(graph::Dict{String, Vector{String}})
+    # Build direct reverse dependency map
+    rev = Dict{String, Set{String}}()
+    for (pkg, deps) in graph
+        for dep in deps
+            if !haskey(rev, dep)
+                rev[dep] = Set{String}()
+            end
+            push!(rev[dep], pkg)
+        end
+    end
+
+    # Compute transitive closure via DFS
+    function get_all_rdeps!(visited::Set{String}, pkg::String)
+        pkg in visited && return
+        push!(visited, pkg)
+        for rdep in get(rev, pkg, Set{String}())
+            get_all_rdeps!(visited, rdep)
+        end
+        return
+    end
+
+    transitive = Dict{String, Set{String}}()
+    for pkg in keys(graph)
+        visited = Set{String}()
+        get_all_rdeps!(visited, pkg)
+        delete!(visited, pkg)  # don't include self
+        transitive[pkg] = visited
+    end
+
+    return transitive
+end
+
+struct TestGroupConfig
+    versions::Vector{String}
+    runner::Any  # String or Vector{String}
+    timeout::Int
+    num_threads::Int
+    local_only::Bool
+end
+
+function load_test_groups(lib_dir::String, pkg::String)
+    groups_file = joinpath(lib_dir, pkg, "test", "test_groups.toml")
+    if isfile(groups_file)
+        toml = TOML.parsefile(groups_file)
+        groups = Dict{String, TestGroupConfig}()
+        for (name, config) in toml
+            versions = convert(Vector{String}, config["versions"])
+            runner_raw = get(config, "runner", "ubuntu-latest")
+            runner = runner_raw isa Vector ? convert(Vector{String}, runner_raw) : runner_raw::String
+            timeout = Int(get(config, "timeout", 120))
+            num_threads = Int(get(config, "num_threads", 1))
+            local_only = Bool(get(config, "local_only", false))
+            groups[name] = TestGroupConfig(versions, runner, timeout, num_threads, local_only)
+        end
+        return groups
+    end
+    return Dict{String, TestGroupConfig}(
+        k => TestGroupConfig(v, "ubuntu-latest", 120, 1, false) for (k, v) in DEFAULT_TEST_GROUPS
+    )
+end
+
+"""
+Return (directly_changed, transitively_affected) package sets.
+
+Directly changed packages get their full version matrix from test_groups.toml.
+Transitively affected packages (reverse deps) only run on version "1".
+"""
+function compute_affected(
+        changed_files::Vector{String},
+        graph::Dict{String, Vector{String}},
+        reverse_deps::Dict{String, Set{String}}
+    )
+    direct = Set{String}()
+    transitive = Set{String}()
+    for filepath in changed_files
+        filepath = strip(filepath)
+        isempty(filepath) && continue
+
+        parts = split(filepath, '/')
+        if length(parts) >= 2 && parts[1] == "lib" && haskey(graph, String(parts[2]))
+            pkg = String(parts[2])
+            push!(direct, pkg)
+            # Only propagate to reverse deps for src/ or Project.toml changes.
+            # Test-only changes don't affect dependents.
+            if length(parts) >= 3 &&
+                    (parts[3] == "src" || (parts[3] == "Project.toml" && length(parts) == 3))
+                union!(transitive, get(reverse_deps, pkg, Set{String}()))
+            end
+        end
+    end
+    # Packages that are both direct and transitive get the full matrix (direct wins).
+    setdiff!(transitive, direct)
+    return (direct, transitive)
+end
+
+# Entries to exclude from the matrix.
+# Each entry is (group, version) where group is the CI GROUP string.
+# See: https://github.com/SciML/OrdinaryDiffEq.jl/issues/2977
+const EXCLUDES = Set(
+    [
+        ("OrdinaryDiffEqBDF", "pre"),  # JET resolution fails on pre-release Julia
+    ]
+)
+
+const DOWNSTREAM_VERSION = "1"
+
+function build_matrix(
+        direct::Set{String}, transitive::Set{String}, lib_dir::String
+    )
+    entries = []
+    for pkg in sort!(collect(union(direct, transitive)))
+        groups = load_test_groups(lib_dir, pkg)
+        is_downstream = pkg in transitive
+        for group_name in sort!(collect(keys(groups)))
+            config = groups[group_name]
+            # local_only groups don't run when this package was only pulled
+            # in via the reverse-dependency graph.
+            is_downstream && config.local_only && continue
+            ci_group = group_name == "Core" ? pkg : "$(pkg)_$(group_name)"
+            # Downstream (transitive) deps only run on latest stable.
+            versions = is_downstream ? [DOWNSTREAM_VERSION] : config.versions
+            for ver in versions
+                (ci_group, ver) in EXCLUDES && continue
+                push!(
+                    entries,
+                    (;
+                        group = ci_group, version = ver, runner = config.runner,
+                        timeout = config.timeout, num_threads = config.num_threads,
+                    )
+                )
+            end
+        end
+    end
+    return entries
+end
+
+# Minimal JSON serialization (no external dependency needed)
+function json_value(v::String)
+    return print("\"", v, "\"")
+end
+function json_value(v::Vector)
+    print("[")
+    for (j, item) in enumerate(v)
+        j > 1 && print(",")
+        json_value(item)
+    end
+    return print("]")
+end
+function json_value(v::Int)
+    return print(v)
+end
+
+function print_json(entries)
+    print("[")
+    for (i, entry) in enumerate(entries)
+        i > 1 && print(",")
+        print("{\"group\":\"", entry.group, "\",\"version\":\"", entry.version, "\",\"runner\":")
+        json_value(entry.runner)
+        print(",\"timeout\":", entry.timeout, ",\"num_threads\":", entry.num_threads, "}")
+    end
+    return println("]")
+end
+
+function main()
+    if length(ARGS) < 1
+        println(stderr, "Usage: julia $(PROGRAM_FILE) <repo_root>")
+        exit(1)
+    end
+
+    repo_root = ARGS[1]
+    lib_dir = joinpath(repo_root, "lib")
+
+    if !isdir(lib_dir)
+        println(stderr, "Error: $lib_dir is not a directory")
+        exit(1)
+    end
+
+    graph = build_dependency_graph(lib_dir)
+    reverse_deps = compute_reverse_deps(graph)
+
+    changed_files = split(read(stdin, String), '\n')
+    direct, transitive = compute_affected(collect(String, changed_files), graph, reverse_deps)
+
+    matrix = build_matrix(direct, transitive, lib_dir)
+    return print_json(matrix)
+end
+
+main()


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Draft.

Enables the SciML **monorepos** (the `lib/*` sublibrary layout) to use centralized reusable workflows for sublibrary CI, matching **OrdinaryDiffEq.jl's** form, so they stop carrying bespoke `SublibraryCI.yml`/`DowngradeSublibraries.yml`.

- **`scripts/compute_affected_sublibraries.jl`** — the dependency-graph change detector lifted from OrdinaryDiffEq.jl (already repo-agnostic: takes a repo path, reads per-sublibrary `lib/<name>/test/test_groups.toml`, emits the affected-sublibrary matrix from the git diff; direct changes → full version matrix, reverse-dep-affected → version "1").
- **`sublibrary-tests.yml`** (reusable) — `detect-changes` runs the shared script (fetched by checking out `SciML/.github`) and outputs a dynamic matrix; the `test` job runs each affected sublibrary's group at its configured version/runner/timeout/threads. Mirrors ODE's `SublibraryCI.yml`.
- **`sublibrary-downgrade.yml`** (reusable) — auto-discovers `lib/*` (minus an `exclude` input) and runs `julia-downgrade-compat` per sublibrary, with `skip`/`julia-version`/`group-env`/`allow-reresolve` inputs. Generalizes ODE's `DowngradeSublibraries.yml`.

Monorepos consume these as one-line callers with `secrets: "inherit"`.

**Prototype:** a companion OrdinaryDiffEq.jl PR converts its two bespoke sublibrary workflows to callers of these (pinned `@v1`), to verify the reusable form reproduces today's behavior before lifting to the other monorepos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)