### PR TITLE
tests.yml: add num-threads input + sublibrary (project) support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,11 @@ on:
         default: ""
         required: false
         type: string
+      num-threads:
+        description: "Value of JULIA_NUM_THREADS for the test run (e.g. set to 2 to exercise multi-threaded code paths)"
+        default: "1"
+        required: false
+        type: string
       self-hosted:
         description: "Run the job needs on a self hosted machine"
         default: false
@@ -81,8 +86,38 @@ jobs:
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: "Develop in-repo [sources] path deps of ${{ inputs.project }}"
+        if: "${{ inputs.buildpkg && inputs.project != '@.' && inputs.project != '.' }}"
+        shell: julia --color=yes {0}
+        run: |
+          using Pkg
+          proj = raw"${{ inputs.project }}"
+          # On Julia < 1.11 the [sources] section is not auto-resolved during
+          # build/test, so develop any in-repo path deps the sub-project (e.g. a
+          # lib/* sublibrary) declares. No-op on >= 1.11 and for projects without
+          # a [sources] section.
+          if VERSION < v"1.11.0-DEV.0"
+            tomlpath = joinpath(proj, "Project.toml")
+            if isfile(tomlpath)
+              toml = Pkg.TOML.parsefile(tomlpath)
+              if haskey(toml, "sources")
+                Pkg.activate(proj)
+                specs = Pkg.PackageSpec[]
+                for (dep, spec) in toml["sources"]
+                  if spec isa Dict && haskey(spec, "path")
+                    p = normpath(joinpath(proj, spec["path"]))
+                    isdir(p) && push!(specs, Pkg.PackageSpec(path = p))
+                  end
+                end
+                isempty(specs) || Pkg.develop(specs)
+              end
+            end
+          end
+
       - uses: julia-actions/julia-buildpkg@v1
         if: "${{ inputs.buildpkg }}"
+        with:
+          project: "${{ inputs.project }}"
 
       - name: "Run tests ${{ inputs.self-hosted && '' || format('on {0}', inputs.os) }} with Julia v${{ inputs.julia-version }}"
         uses: julia-actions/julia-runtest@v1
@@ -92,6 +127,7 @@ jobs:
           coverage: "${{ inputs.coverage }}"
         env:
           GROUP: "${{ inputs.group }}"
+          JULIA_NUM_THREADS: "${{ inputs.num-threads }}"
 
       - uses: julia-actions/julia-processcoverage@v1
         if: "${{ inputs.coverage }}"


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Draft.

Two backward-compatible additions to `tests.yml` so the last repos keeping bespoke test CI can move onto the reusable workflow:

- **`num-threads`** input → sets `JULIA_NUM_THREADS` on the runtest step (default `"1"` = unchanged). Unblocks **RecursiveArrayTools.jl**, whose bespoke `Tests.yml` runs with 2 threads to cover the threaded regression path (issue #570) — `tests.yml` had no way to express that.
- **`project` passed to `julia-buildpkg`** + an **in-repo `[sources]` develop step**, so the workflow can build+test a `lib/*` **sublibrary** (`project: lib/Foo`). The develop step only runs for non-root projects on Julia < 1.11 (≥1.11 auto-resolves `[sources]`); skipped for every existing caller. Unblocks **Corleone.jl#72** (CorleoneOED sublibrary) without reverting to bespoke CI.

All defaults preserve current behavior for the ~130 existing consumers.

Follow-ups once on `v1`: convert RecursiveArrayTools to a `tests.yml@v1` caller (`num-threads: 2`), and rework Corleone#72 to a matrixed `{group, project}` caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)