### PR TITLE
tests.yml: default num-threads to 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,8 @@ on:
         required: false
         type: string
       num-threads:
-        description: "Value of JULIA_NUM_THREADS for the test run (e.g. set to 2 to exercise multi-threaded code paths)"
-        default: "1"
+        description: "Value of JULIA_NUM_THREADS for the test run. Defaults to 2 so multi-threaded code paths are exercised (GitHub-hosted runners have >= 4 vCPUs); set to 1 for a strictly single-threaded run."
+        default: "2"
         required: false
         type: string
       self-hosted:


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Draft.

Default `num-threads` to **2** (was 1). GitHub-hosted runners have ≥4 vCPUs and the self-hosted fleet has many more, so there's no cost — and it means **every** centralized-tests repo exercises multi-threaded code paths by default, instead of only where a caller opts in (e.g. RecursiveArrayTools' #570 regression). `num-threads: "1"` is still available for a strictly single-threaded run.

⚠️ **Fleet-wide test-environment change:** on the next CI run, every `tests.yml@v1` consumer runs 2-threaded. Repos with latent thread-safety bugs or tests that assume `nthreads() == 1` may newly go red — those are genuine issues to fix (or set `num-threads: "1"`). This is the same "surface real problems" tradeoff as the test-all downgrade work.

Once on `v1`, RecursiveArrayTools' explicit `num-threads: 2` (PR #604) becomes redundant (harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)