### PR TITLE
Promote num-threads=2 default to v1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,8 @@ on:
         required: false
         type: string
       num-threads:
-        description: "Value of JULIA_NUM_THREADS for the test run (e.g. set to 2 to exercise multi-threaded code paths)"
-        default: "1"
+        description: "Value of JULIA_NUM_THREADS for the test run. Defaults to 2 so multi-threaded code paths are exercised (GitHub-hosted runners have >= 4 vCPUs); set to 1 for a strictly single-threaded run."
+        default: "2"
         required: false
         type: string
       self-hosted:


### PR DESCRIPTION
Promotes #45 (default `tests.yml` num-threads 1->2) to `@v1`. Delta is just `tests.yml`.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)