### PR TITLE
Add tag-based release scheme (retire master->v1 branch promotion)

### DIFF
--- a/.github/workflows/major-version-tag.yml
+++ b/.github/workflows/major-version-tag.yml
@@ -1,0 +1,30 @@
+name: "Maintain major version tag"
+
+# When a semver release tag (vX.Y.Z) is pushed, move the floating major tag
+# (vX) to point at it. Consumers pin `@vX` (e.g. tests.yml@v1) and thus track
+# the latest vX.Y.Z automatically, while exact pins (@vX.Y.Z) stay immutable.
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+jobs:
+  move-major-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "Point the major tag at this release"
+        run: |
+          set -euo pipefail
+          full="${GITHUB_REF_NAME}"                       # e.g. v1.2.3
+          major="v$(printf '%s' "${full#v}" | cut -d. -f1)"  # -> v1
+          echo "Moving ${major} -> ${full} (${GITHUB_SHA})"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -f "${major}" "${GITHUB_SHA}"
+          git push -f origin "refs/tags/${major}"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,52 @@
+# Releasing the SciML reusable workflows
+
+Consumers pin the **major tag** of the reusable workflows, e.g.:
+
+```yaml
+uses: "SciML/.github/.github/workflows/tests.yml@v1"
+```
+
+`@v1` is a *moving tag* that always points at the latest `v1.x.y` release.
+Repos that want to pin exactly can use `@v1.2.3` (immutable).
+
+## Cutting a release
+
+1. Land the changes on `master` as usual (PRs).
+2. Tag the release commit with the next semver tag and push it:
+
+   ```bash
+   git checkout master && git pull
+   git tag -a v1.3.0 -m "v1.3.0"
+   git push origin v1.3.0
+   ```
+
+   (Or publish a GitHub Release with that tag.)
+3. The `Maintain major version tag` workflow automatically moves `v1` to the
+   new release commit. Nothing else to do — every `@v1` consumer now gets it.
+
+- **Bug/feature, backward compatible:** bump patch/minor (`v1.x.y`); `v1` moves.
+- **Breaking change** (e.g. dropping an input, switching the formatter): tag
+  `v2.0.0`. `@v1` consumers are unaffected; they opt in by changing to `@v2`
+  when ready. Keep moving `v1` for `v1.x` backports if needed.
+
+This replaces the old `master` -> `v1` *branch* promotion: there is no longer
+a `v1` branch, and no per-change promotion PR. Just merge to `master` and tag
+when you want consumers to pick the change up.
+
+## One-time migration (admin)
+
+The repo is moving from a floating `v1` **branch** to tags. A maintainer with
+push access runs once (when `v1` branch == `master`):
+
+```bash
+git fetch origin
+# tag the current release state (master, which equals the v1 branch today):
+git tag -a v1.0.0 origin/master -m "v1.0.0 — first tagged release"
+git tag v1 origin/master
+git push origin refs/tags/v1.0.0 refs/tags/v1
+# now retire the v1 BRANCH so @v1 resolves to the tag (do this AFTER the tags exist):
+git push origin --delete refs/heads/v1
+```
+
+`@v1` consumers are unaffected: the `v1` tag points at the same commit the
+`v1` branch did.


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Draft.

Replaces the floating `v1` **branch** + per-change `master`→`v1` promotion PRs with standard semver tags.

- **`major-version-tag.yml`** — when a `vX.Y.Z` tag is pushed, force-moves the floating major tag `vX` to it. Consumers keep pinning `@v1` (now a *tag*) and track the latest `v1.x.y`; exact pins `@v1.2.3` are immutable. Breaking changes → `v2`.
- **`RELEASING.md`** — the release flow (merge to `master`, tag `vX.Y.Z`, the workflow moves `vX`) + the one-time migration steps.

### One-time admin step (needs push/admin — I can't do this via a PR)
`v1` branch currently equals `master` (after #48), so bootstrapping is clean and `@v1` consumers are unaffected:
```bash
git fetch origin
git tag -a v1.0.0 origin/master -m "v1.0.0 — first tagged release"
git tag v1 origin/master
git push origin refs/tags/v1.0.0 refs/tags/v1
git push origin --delete refs/heads/v1   # retire the branch; @v1 now = the tag
```
After that, no more promotion PRs — merge to `master` and tag when you want consumers to pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)