### PR TITLE
tests.yml: transitive sublibrary [sources] develop (project model)

### DIFF
--- a/.github/workflows/sublibrary-tests.yml
+++ b/.github/workflows/sublibrary-tests.yml
@@ -93,33 +93,6 @@ jobs:
         continue-on-error: true
         with:
           cache-compiled: 'false'
-      - name: "Refresh General registry directly from git"
-        shell: julia --color=yes --project=. {0}
-        run: |
-          using Pkg
-          # Refresh General to dodge pkg-server lag BEFORE the develop step:
-          # develop's resolve needs current versions of registered deps, and the
-          # cached pkg-server registry is often stale.
-          #
-          # IMPORTANT: never rm the registry on self-hosted runners. They share
-          # one depot across concurrent matrix jobs, so removing General leaves a
-          # window where other jobs resolve against a missing registry ->
-          # corruption and lock-ups. Destructive re-clone only on github-hosted
-          # (isolated per-job depot); on self-hosted do a non-destructive update
-          # (Pkg serialises it via the registry lock).
-          if get(ENV, "RUNNER_ENVIRONMENT", "") == "self-hosted"
-              try
-                  Pkg.Registry.update("General")
-              catch
-                  try; Pkg.Registry.add("General"); catch; end
-              end
-          else
-              try
-                  Pkg.Registry.rm("General")
-              catch
-              end
-              Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
-          end
       - name: "Develop local path deps (Julia < 1.11)"
         shell: julia --color=yes --project=. {0}
         run: |

--- a/.github/workflows/sublibrary-tests.yml
+++ b/.github/workflows/sublibrary-tests.yml
@@ -97,14 +97,29 @@ jobs:
         shell: julia --color=yes --project=. {0}
         run: |
           using Pkg
-          # Force a fresh git clone of General to dodge pkg-server lag, BEFORE
-          # the develop step: develop's resolve needs current versions of
-          # registered deps, and the cached pkg-server registry is often stale.
-          try
-              Pkg.Registry.rm("General")
-          catch
+          # Refresh General to dodge pkg-server lag BEFORE the develop step:
+          # develop's resolve needs current versions of registered deps, and the
+          # cached pkg-server registry is often stale.
+          #
+          # IMPORTANT: never rm the registry on self-hosted runners. They share
+          # one depot across concurrent matrix jobs, so removing General leaves a
+          # window where other jobs resolve against a missing registry ->
+          # corruption and lock-ups. Destructive re-clone only on github-hosted
+          # (isolated per-job depot); on self-hosted do a non-destructive update
+          # (Pkg serialises it via the registry lock).
+          if get(ENV, "RUNNER_ENVIRONMENT", "") == "self-hosted"
+              try
+                  Pkg.Registry.update("General")
+              catch
+                  try; Pkg.Registry.add("General"); catch; end
+              end
+          else
+              try
+                  Pkg.Registry.rm("General")
+              catch
+              end
+              Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
           end
-          Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
       - name: "Develop local path deps (Julia < 1.11)"
         shell: julia --color=yes --project=. {0}
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,22 @@ jobs:
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: "Refresh General registry from git (sublibrary projects)"
+        if: "${{ inputs.project != '@.' && inputs.project != '.' }}"
+        shell: julia --color=yes {0}
+        run: |
+          using Pkg
+          # Sublibrary resolves often need just-registered sibling/parent
+          # versions that the cached pkg-server registry is too stale to have
+          # yet ("expected package X to be registered"). Re-clone General from
+          # git so the resolve below sees current versions. Only runs for
+          # sublibrary (project != @.) jobs.
+          try
+              Pkg.Registry.rm("General")
+          catch
+          end
+          Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
+
       - name: "Develop in-repo [sources] path deps of ${{ inputs.project }}"
         if: "${{ inputs.buildpkg && inputs.project != '@.' && inputs.project != '.' }}"
         shell: julia --color=yes {0}
@@ -93,25 +109,33 @@ jobs:
           using Pkg
           proj = raw"${{ inputs.project }}"
           # On Julia < 1.11 the [sources] section is not auto-resolved during
-          # build/test, so develop any in-repo path deps the sub-project (e.g. a
-          # lib/* sublibrary) declares. No-op on >= 1.11 and for projects without
-          # a [sources] section.
+          # build/test, so develop the in-repo path deps the sub-project (e.g. a
+          # lib/* sublibrary) declares -- transitively, since a source dep can
+          # itself declare further [sources]. No-op on >= 1.11 and for projects
+          # without a [sources] section.
           if VERSION < v"1.11.0-DEV.0"
-            tomlpath = joinpath(proj, "Project.toml")
-            if isfile(tomlpath)
+            Pkg.activate(proj)
+            developed = Set{String}([normpath(abspath(proj))])  # never develop the active project (cyclic [sources])
+            specs = Pkg.PackageSpec[]
+            queue = String[proj]
+            while !isempty(queue)
+              dir = popfirst!(queue)
+              tomlpath = joinpath(dir, "Project.toml")
+              isfile(tomlpath) || continue
               toml = Pkg.TOML.parsefile(tomlpath)
-              if haskey(toml, "sources")
-                Pkg.activate(proj)
-                specs = Pkg.PackageSpec[]
-                for (dep, spec) in toml["sources"]
-                  if spec isa Dict && haskey(spec, "path")
-                    p = normpath(joinpath(proj, spec["path"]))
-                    isdir(p) && push!(specs, Pkg.PackageSpec(path = p))
+              haskey(toml, "sources") || continue
+              for (dep, spec) in toml["sources"]
+                if spec isa Dict && haskey(spec, "path")
+                  p = normpath(abspath(joinpath(dir, spec["path"])))
+                  if isdir(p) && !(p in developed)
+                    push!(developed, p)
+                    push!(specs, Pkg.PackageSpec(path = p))
+                    push!(queue, p)  # resolve this dep's own [sources] too
                   end
                 end
-                isempty(specs) || Pkg.develop(specs)
               end
             end
+            isempty(specs) || Pkg.develop(specs)
           end
 
       - uses: julia-actions/julia-buildpkg@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,36 +86,6 @@ jobs:
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: "Refresh General registry from git (sublibrary projects)"
-        if: "${{ inputs.project != '@.' && inputs.project != '.' }}"
-        shell: julia --color=yes {0}
-        run: |
-          using Pkg
-          # Sublibrary resolves often need just-registered sibling/parent
-          # versions that the cached pkg-server registry is too stale to have
-          # yet ("expected package X to be registered"). Refresh General so the
-          # resolve below sees current versions. Only runs for sublibrary
-          # (project != @.) jobs.
-          #
-          # IMPORTANT: never rm the registry on self-hosted runners. They share
-          # one depot across concurrent jobs, so removing General leaves a window
-          # where other jobs resolve against a missing registry -> corruption and
-          # lock-ups. Destructive re-clone only on github-hosted (isolated per-job
-          # depot); on self-hosted do a non-destructive update (Pkg serialises it).
-          if get(ENV, "RUNNER_ENVIRONMENT", "") == "self-hosted"
-              try
-                  Pkg.Registry.update("General")
-              catch
-                  try; Pkg.Registry.add("General"); catch; end
-              end
-          else
-              try
-                  Pkg.Registry.rm("General")
-              catch
-              end
-              Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
-          end
-
       - name: "Develop in-repo [sources] path deps of ${{ inputs.project }}"
         if: "${{ inputs.buildpkg && inputs.project != '@.' && inputs.project != '.' }}"
         shell: julia --color=yes {0}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,14 +93,28 @@ jobs:
           using Pkg
           # Sublibrary resolves often need just-registered sibling/parent
           # versions that the cached pkg-server registry is too stale to have
-          # yet ("expected package X to be registered"). Re-clone General from
-          # git so the resolve below sees current versions. Only runs for
-          # sublibrary (project != @.) jobs.
-          try
-              Pkg.Registry.rm("General")
-          catch
+          # yet ("expected package X to be registered"). Refresh General so the
+          # resolve below sees current versions. Only runs for sublibrary
+          # (project != @.) jobs.
+          #
+          # IMPORTANT: never rm the registry on self-hosted runners. They share
+          # one depot across concurrent jobs, so removing General leaves a window
+          # where other jobs resolve against a missing registry -> corruption and
+          # lock-ups. Destructive re-clone only on github-hosted (isolated per-job
+          # depot); on self-hosted do a non-destructive update (Pkg serialises it).
+          if get(ENV, "RUNNER_ENVIRONMENT", "") == "self-hosted"
+              try
+                  Pkg.Registry.update("General")
+              catch
+                  try; Pkg.Registry.add("General"); catch; end
+              end
+          else
+              try
+                  Pkg.Registry.rm("General")
+              catch
+              end
+              Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
           end
-          Pkg.Registry.add(Pkg.RegistrySpec(url = "https://github.com/JuliaRegistries/General.git"))
 
       - name: "Develop in-repo [sources] path deps of ${{ inputs.project }}"
         if: "${{ inputs.buildpkg && inputs.project != '@.' && inputs.project != '.' }}"


### PR DESCRIPTION
> [!NOTE]
> Please ignore until reviewed by @ChrisRackauckas. Draft.

Lets a monorepo test a `lib/*` sublibrary via a `project: lib/X` caller (the project model), so the `[sources]`/Julia-1.10 handling lives in the reusable workflow instead of being copy-pasted into each repo's `runtests.jl`.

For `project != '@.'` (sublibrary) jobs only — **zero impact** on the ~130 ordinary callers:
- **Transitive `[sources]` develop** on Julia < 1.11 (a source dep can declare its own `[sources]`; e.g. a tableaus package under a solver sublib), with the active-project guard against the cyclic-`[sources]` error. Verified on ODE `lib/OrdinaryDiffEqDefault` (48 transitive deps incl. `RosenbrockTableaus`).

No explicit registry refresh: because the transitive develop git-develops every in-repo dep, nothing just-released is resolved from the registry — only third-party deps, which the standard `eager` General (set up by `julia-buildpkg`) already covers. This also keeps the workflow free of any registry mutation, so there's **no self-hosted lock-up hazard** (also removed the unconditional `rm`+clone that `sublibrary-tests.yml` previously ran on ODE's self-hosted jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)