### PR TITLE
ci(sublibrary-downgrade): build matrix JSON in pure shell (no jq/python3)

### DIFF
--- a/.github/workflows/sublibrary-downgrade.yml
+++ b/.github/workflows/sublibrary-downgrade.yml
@@ -69,7 +69,8 @@ jobs:
               $skipit || projects+=("$d")
             done
           fi
-          json=$(printf '%s\n' "${projects[@]}" | grep . | python3 -c 'import sys,json; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))')
+          # jq is preinstalled on GitHub-hosted runners; don't assume python3.
+          json=$(printf '%s\n' "${projects[@]}" | grep . | jq -R . | jq -sc .)
           echo "Sublibraries: $json"
           echo "projects=$json" >> "$GITHUB_OUTPUT"
           [ "$json" = "[]" ] && echo "has_any=false" >> "$GITHUB_OUTPUT" || echo "has_any=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sublibrary-downgrade.yml
+++ b/.github/workflows/sublibrary-downgrade.yml
@@ -69,8 +69,15 @@ jobs:
               $skipit || projects+=("$d")
             done
           fi
-          # jq is preinstalled on GitHub-hosted runners; don't assume python3.
-          json=$(printf '%s\n' "${projects[@]}" | grep . | jq -R . | jq -sc .)
+          # Build the JSON array in pure shell -- neither jq nor python3 is
+          # guaranteed on a self-hosted runner. lib/* names have no JSON-special
+          # characters, so plain quoting is safe.
+          json=""
+          for p in "${projects[@]}"; do
+            [ -n "$p" ] || continue
+            if [ -z "$json" ]; then json="\"$p\""; else json="$json,\"$p\""; fi
+          done
+          json="[$json]"
           echo "Sublibraries: $json"
           echo "projects=$json" >> "$GITHUB_OUTPUT"
           [ "$json" = "[]" ] && echo "has_any=false" >> "$GITHUB_OUTPUT" || echo "has_any=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The `discover` job built its sublibrary matrix JSON with `python3 -c`, assuming Python is on the runner. Neither python3 nor jq is guaranteed on a self-hosted runner, so build the JSON array with plain shell quoting instead (`lib/*` names have no JSON-special characters).

Same fix applied to the project-model `SublibraryCI.yml` callers in BoundaryValueDiffEq#499 / NonlinearSolve#954 / Corleone#77.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)