### PR TITLE
ci: reusable sublibrary-project-tests.yml (change detection + full test_groups matrix)

### DIFF
--- a/.github/workflows/sublibrary-project-tests.yml
+++ b/.github/workflows/sublibrary-project-tests.yml
@@ -1,0 +1,88 @@
+name: "Reusable Sublibrary CI (project model)"
+
+# Lists every lib/<name> sublibrary with a Project.toml and runs each one's
+# test suite via the reusable tests.yml workflow (project: lib/<name>).
+# tests.yml transitively git-develops the sublibrary's in-repo [sources] path
+# deps, so no root runtests.jl GROUP dispatcher is needed in the calling repo.
+#
+# Contrast sublibrary-tests.yml, which uses GROUP dispatch + dependency-graph
+# change detection and suits very large monorepos (e.g. OrdinaryDiffEq); this
+# project-model workflow tests every sublibrary on every run and suits the
+# smaller monorepos.
+#
+# Caller (per repo) only supplies its branch triggers + concurrency:
+#
+#   jobs:
+#     sublibraries:
+#       uses: SciML/.github/.github/workflows/sublibrary-project-tests.yml@v1
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      julia-version:
+        description: "Julia version for each sublibrary test run"
+        default: "1"
+        required: false
+        type: string
+      coverage:
+        description: "Collect per-sublibrary coverage (uploaded with directories pointed at lib/<name>)"
+        default: true
+        required: false
+        type: boolean
+      self-hosted:
+        description: "Run the sublibrary test jobs on a self-hosted runner"
+        default: false
+        required: false
+        type: boolean
+      os:
+        description: "Runner OS for the sublibrary test jobs (ignored when self-hosted)"
+        default: "ubuntu-latest"
+        required: false
+        type: string
+      num-threads:
+        description: "JULIA_NUM_THREADS for each sublibrary test run (see tests.yml)"
+        default: "auto"
+        required: false
+        type: string
+
+jobs:
+  list-sublibraries:
+    runs-on: ubuntu-latest
+    outputs:
+      projects: ${{ steps.list.outputs.projects }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: "List lib/* sublibraries"
+        id: list
+        run: |
+          # Build the JSON array in pure shell -- neither jq nor python3 is
+          # guaranteed on the runner. lib/* names have no JSON-special
+          # characters, so plain quoting is safe; yields [] when none match.
+          projects=""
+          for d in lib/*/; do
+            d="${d%/}"
+            [ -f "$d/Project.toml" ] || continue
+            if [ -z "$projects" ]; then projects="\"$d\""; else projects="$projects,\"$d\""; fi
+          done
+          projects="[$projects]"
+          echo "Sublibraries: $projects"
+          echo "projects=$projects" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: list-sublibraries
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJson(needs.list-sublibraries.outputs.projects) }}
+    name: "Sublibrary - ${{ matrix.project }}"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      project: "${{ matrix.project }}"
+      julia-version: "${{ inputs.julia-version }}"
+      coverage: ${{ inputs.coverage }}
+      coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
+      self-hosted: ${{ inputs.self-hosted }}
+      os: "${{ inputs.os }}"
+      num-threads: "${{ inputs.num-threads }}"
+    secrets: "inherit"

--- a/.github/workflows/sublibrary-project-tests.yml
+++ b/.github/workflows/sublibrary-project-tests.yml
@@ -1,14 +1,21 @@
 name: "Reusable Sublibrary CI (project model)"
 
-# Lists every lib/<name> sublibrary with a Project.toml and runs each one's
-# test suite via the reusable tests.yml workflow (project: lib/<name>).
+# Tests the lib/<name> sublibraries affected by a push/PR via the reusable
+# tests.yml workflow (project: lib/<name>). The affected set is computed from
+# the sublibrary dependency graph (scripts/compute_affected_sublibraries.jl
+# --projects): a changed sublibrary plus every sublibrary that transitively
+# depends on it; test-only changes don't propagate to dependents; changes
+# outside lib/ select nothing. Set test-all: true to test every sublibrary
+# regardless of the diff.
+#
 # tests.yml transitively git-develops the sublibrary's in-repo [sources] path
 # deps, so no root runtests.jl GROUP dispatcher is needed in the calling repo.
 #
-# Contrast sublibrary-tests.yml, which uses GROUP dispatch + dependency-graph
-# change detection and suits very large monorepos (e.g. OrdinaryDiffEq); this
-# project-model workflow tests every sublibrary on every run and suits the
-# smaller monorepos.
+# Contrast sublibrary-tests.yml, which uses the same change detection but the
+# GROUP-dispatch model with per-sublibrary test_groups.toml (multiple Julia
+# versions, custom runners/timeouts/threads, GPU groups). Use that for repos
+# that need those per-group knobs (e.g. OrdinaryDiffEq); use this project-model
+# workflow when each lib/<name>/test/runtests.jl is a self-contained suite.
 #
 # Caller (per repo) only supplies its branch triggers + concurrency:
 #
@@ -45,36 +52,76 @@ on:
         default: "auto"
         required: false
         type: string
+      test-all:
+        description: "Test every lib/<name> sublibrary regardless of the diff (e.g. scheduled or manual full runs)"
+        default: false
+        required: false
+        type: boolean
+      dotgithub-ref:
+        description: "Ref of SciML/.github to source the affected-sublibrary detection script from"
+        default: "v1"
+        required: false
+        type: string
 
 jobs:
-  list-sublibraries:
+  detect:
     runs-on: ubuntu-latest
     outputs:
-      projects: ${{ steps.list.outputs.projects }}
+      projects: ${{ steps.compute.outputs.projects }}
+      has_changes: ${{ steps.compute.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v6
-      - name: "List lib/* sublibraries"
-        id: list
+        with:
+          fetch-depth: 0
+      - name: "Checkout SciML/.github for the detection script"
+        if: "${{ !inputs.test-all }}"
+        uses: actions/checkout@v6
+        with:
+          repository: SciML/.github
+          ref: "${{ inputs.dotgithub-ref }}"
+          path: .sciml-dotgithub
+      - uses: julia-actions/setup-julia@v3
+        if: "${{ !inputs.test-all }}"
+        with:
+          version: "1"
+      - name: "Compute affected sublibraries"
+        id: compute
         run: |
-          # Build the JSON array in pure shell -- neither jq nor python3 is
-          # guaranteed on the runner. lib/* names have no JSON-special
-          # characters, so plain quoting is safe; yields [] when none match.
-          projects=""
-          for d in lib/*/; do
-            d="${d%/}"
-            [ -f "$d/Project.toml" ] || continue
-            if [ -z "$projects" ]; then projects="\"$d\""; else projects="$projects,\"$d\""; fi
-          done
-          projects="[$projects]"
-          echo "Sublibraries: $projects"
+          if [ "${{ inputs.test-all }}" = "true" ]; then
+            # Pure-shell listing of every lib/* (no jq/python3); test-all bypass.
+            projects=""
+            for d in lib/*/; do
+              d="${d%/}"
+              [ -f "$d/Project.toml" ] || continue
+              if [ -z "$projects" ]; then projects="\"$d\""; else projects="$projects,\"$d\""; fi
+            done
+            projects="[$projects]"
+          else
+            if [ "${{ github.event_name }}" = "push" ]; then
+              CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null || git diff --name-only HEAD~1 HEAD)
+            else
+              git fetch origin ${{ github.event.pull_request.base.ref }}
+              CHANGED=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD)
+            fi
+            echo "Changed files under lib/:"
+            echo "$CHANGED" | grep "^lib/" || echo "(none)"
+            projects=$(echo "$CHANGED" | julia .sciml-dotgithub/scripts/compute_affected_sublibraries.jl . --projects)
+          fi
+          echo "Affected sublibraries: $projects"
           echo "projects=$projects" >> "$GITHUB_OUTPUT"
+          if [ "$projects" = "[]" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
 
   test:
-    needs: list-sublibraries
+    needs: detect
+    if: needs.detect.outputs.has_changes == 'true'
     strategy:
       fail-fast: false
       matrix:
-        project: ${{ fromJson(needs.list-sublibraries.outputs.projects) }}
+        project: ${{ fromJson(needs.detect.outputs.projects) }}
     name: "Sublibrary - ${{ matrix.project }}"
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:

--- a/.github/workflows/sublibrary-project-tests.yml
+++ b/.github/workflows/sublibrary-project-tests.yml
@@ -3,57 +3,56 @@ name: "Reusable Sublibrary CI (project model)"
 # Tests the lib/<name> sublibraries affected by a push/PR via the reusable
 # tests.yml workflow (project: lib/<name>). The affected set is computed from
 # the sublibrary dependency graph (scripts/compute_affected_sublibraries.jl
-# --projects): a changed sublibrary plus every sublibrary that transitively
-# depends on it; test-only changes don't propagate to dependents; changes
-# outside lib/ select nothing. Set test-all: true to test every sublibrary
-# regardless of the diff.
+# --projects-matrix): a changed sublibrary plus every sublibrary that
+# transitively depends on it; test-only changes don't propagate to dependents;
+# changes outside lib/ select nothing. Set test-all: true to test everything.
 #
-# tests.yml transitively git-develops the sublibrary's in-repo [sources] path
-# deps, so no root runtests.jl GROUP dispatcher is needed in the calling repo.
+# Each affected sublibrary is expanded into its test_groups.toml matrix
+# (multiple Julia versions, GPU/threaded groups on custom runners, per-group
+# timeout/num_threads/local_only), exactly like sublibrary-tests.yml -- but run
+# in the project model: tests.yml with project=lib/<name> and the group passed
+# via group-env-name (e.g. ODEDIFFEQ_TEST_GROUP). Sublibraries with no
+# test_groups.toml get the default Core on [lts,1.11,1,pre] + QA on [1].
+# tests.yml transitively git-develops the sublibrary's in-repo [sources], so no
+# root runtests.jl GROUP dispatcher is needed.
 #
-# Contrast sublibrary-tests.yml, which uses the same change detection but the
-# GROUP-dispatch model with per-sublibrary test_groups.toml (multiple Julia
-# versions, custom runners/timeouts/threads, GPU groups). Use that for repos
-# that need those per-group knobs (e.g. OrdinaryDiffEq); use this project-model
-# workflow when each lib/<name>/test/runtests.jl is a self-contained suite.
-#
-# Caller (per repo) only supplies its branch triggers + concurrency:
+# Caller (per repo) supplies its branch triggers + concurrency; repos whose
+# sublibraries read a non-default group env var or need check-bounds=auto set
+# those once here:
 #
 #   jobs:
 #     sublibraries:
 #       uses: SciML/.github/.github/workflows/sublibrary-project-tests.yml@v1
+#       # with:                                   # OrdinaryDiffEq, e.g.
+#       #   group-env-name: ODEDIFFEQ_TEST_GROUP
+#       #   check-bounds: auto
 #       secrets: inherit
 
 on:
   workflow_call:
     inputs:
-      julia-version:
-        description: "Julia version for each sublibrary test run"
-        default: "1"
-        required: false
-        type: string
       coverage:
         description: "Collect per-sublibrary coverage (uploaded with directories pointed at lib/<name>)"
         default: true
         required: false
         type: boolean
-      self-hosted:
-        description: "Run the sublibrary test jobs on a self-hosted runner"
-        default: false
+      group-env-name:
+        description: "Environment variable name the sublibrary test run reads its group from (default GROUP; OrdinaryDiffEq uses ODEDIFFEQ_TEST_GROUP)"
+        default: "GROUP"
+        required: false
+        type: string
+      check-bounds:
+        description: "Value of julia-runtest's check_bounds (yes/no/auto) for each sublibrary"
+        default: "yes"
+        required: false
+        type: string
+      allow-reresolve:
+        description: "Value of julia-runtest's allow_reresolve for each sublibrary"
+        default: true
         required: false
         type: boolean
-      os:
-        description: "Runner OS for the sublibrary test jobs (ignored when self-hosted)"
-        default: "ubuntu-latest"
-        required: false
-        type: string
-      num-threads:
-        description: "JULIA_NUM_THREADS for each sublibrary test run (see tests.yml)"
-        default: "auto"
-        required: false
-        type: string
       test-all:
-        description: "Test every lib/<name> sublibrary regardless of the diff (e.g. scheduled or manual full runs)"
+        description: "Test every lib/<name> sublibrary (full test_groups matrix) regardless of the diff"
         default: false
         required: false
         type: boolean
@@ -67,49 +66,40 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      projects: ${{ steps.compute.outputs.projects }}
+      matrix: ${{ steps.compute.outputs.matrix }}
       has_changes: ${{ steps.compute.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: "Checkout SciML/.github for the detection script"
-        if: "${{ !inputs.test-all }}"
         uses: actions/checkout@v6
         with:
           repository: SciML/.github
           ref: "${{ inputs.dotgithub-ref }}"
           path: .sciml-dotgithub
       - uses: julia-actions/setup-julia@v3
-        if: "${{ !inputs.test-all }}"
         with:
           version: "1"
       - name: "Compute affected sublibraries"
         id: compute
         run: |
           if [ "${{ inputs.test-all }}" = "true" ]; then
-            # Pure-shell listing of every lib/* (no jq/python3); test-all bypass.
-            projects=""
-            for d in lib/*/; do
-              d="${d%/}"
-              [ -f "$d/Project.toml" ] || continue
-              if [ -z "$projects" ]; then projects="\"$d\""; else projects="$projects,\"$d\""; fi
-            done
-            projects="[$projects]"
+            # Every lib/* file looks "changed" so the script's matrix builder
+            # emits the full per-sublibrary test_groups expansion.
+            CHANGED=$(git ls-files 'lib/*')
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null || git diff --name-only HEAD~1 HEAD)
           else
-            if [ "${{ github.event_name }}" = "push" ]; then
-              CHANGED=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} 2>/dev/null || git diff --name-only HEAD~1 HEAD)
-            else
-              git fetch origin ${{ github.event.pull_request.base.ref }}
-              CHANGED=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD)
-            fi
-            echo "Changed files under lib/:"
-            echo "$CHANGED" | grep "^lib/" || echo "(none)"
-            projects=$(echo "$CHANGED" | julia .sciml-dotgithub/scripts/compute_affected_sublibraries.jl . --projects)
+            git fetch origin ${{ github.event.pull_request.base.ref }}
+            CHANGED=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}...HEAD)
           fi
-          echo "Affected sublibraries: $projects"
-          echo "projects=$projects" >> "$GITHUB_OUTPUT"
-          if [ "$projects" = "[]" ]; then
+          echo "Changed files under lib/:"
+          echo "$CHANGED" | grep "^lib/" || echo "(none)"
+          MATRIX=$(echo "$CHANGED" | julia .sciml-dotgithub/scripts/compute_affected_sublibraries.jl . --projects-matrix)
+          echo "Matrix: $MATRIX"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          if [ "$MATRIX" = "[]" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
@@ -121,15 +111,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        project: ${{ fromJson(needs.detect.outputs.projects) }}
-    name: "Sublibrary - ${{ matrix.project }}"
+        include: ${{ fromJson(needs.detect.outputs.matrix) }}
+    name: "${{ matrix.project }}${{ matrix.group != 'Core' && format(' [{0}]', matrix.group) || '' }} (julia ${{ matrix.version }})"
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       project: "${{ matrix.project }}"
-      julia-version: "${{ inputs.julia-version }}"
+      group: "${{ matrix.group }}"
+      group-env-name: "${{ inputs.group-env-name }}"
+      julia-version: "${{ matrix.version }}"
+      runner: ${{ toJson(matrix.runner) }}
+      timeout-minutes: ${{ matrix.timeout }}
+      num-threads: "${{ matrix.num_threads }}"
+      check-bounds: "${{ inputs.check-bounds }}"
+      allow-reresolve: ${{ inputs.allow-reresolve }}
       coverage: ${{ inputs.coverage }}
       coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
-      self-hosted: ${{ inputs.self-hosted }}
-      os: "${{ inputs.os }}"
-      num-threads: "${{ inputs.num-threads }}"
     secrets: "inherit"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -66,12 +66,38 @@ on:
         description: "Prevent the workflow run from failing if/when the job fails"
         required: false
         type: boolean
+      runner:
+        description: "JSON-encoded runs-on value (string or array of labels, e.g. '[\"self-hosted\",\"Linux\",\"X64\",\"gpu\"]'). When non-empty it overrides self-hosted/os."
+        default: ""
+        required: false
+        type: string
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        default: 360
+        required: false
+        type: number
+      check-bounds:
+        description: "Value of julia-runtest's check_bounds (yes/no/auto)"
+        default: "yes"
+        required: false
+        type: string
+      allow-reresolve:
+        description: "Value of julia-runtest's allow_reresolve"
+        default: true
+        required: false
+        type: boolean
+      group-env-name:
+        description: "Name of the environment variable to set to `group` for the test run (e.g. GROUP or ODEDIFFEQ_TEST_GROUP)"
+        default: "GROUP"
+        required: false
+        type: string
 
 jobs:
   tests:
     name: "Tests${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
     continue-on-error: ${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}
-    runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
+    runs-on: ${{ inputs.runner != '' && fromJson(inputs.runner) || (inputs.self-hosted && 'self-hosted' || inputs.os) }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - uses: actions/checkout@v6
 
@@ -127,14 +153,22 @@ jobs:
         with:
           project: "${{ inputs.project }}"
 
+      - name: "Set test group env (${{ inputs.group-env-name }})"
+        # Set the group under a configurable env var name so sublibraries that
+        # read e.g. ODEDIFFEQ_TEST_GROUP work the same as the default GROUP. The
+        # name must be dynamic, which the env: map can't express, so write it to
+        # $GITHUB_ENV here.
+        run: echo "${{ inputs.group-env-name }}=${{ inputs.group }}" >> "$GITHUB_ENV"
+
       - name: "Run tests ${{ inputs.self-hosted && '' || format('on {0}', inputs.os) }} with Julia v${{ inputs.julia-version }}"
         uses: julia-actions/julia-runtest@v1
         with:
           project: "${{ inputs.project }}"
           depwarn: "${{ inputs.julia-runtest-depwarn }}"
           coverage: "${{ inputs.coverage }}"
+          check_bounds: "${{ inputs.check-bounds }}"
+          allow_reresolve: ${{ inputs.allow-reresolve }}
         env:
-          GROUP: "${{ inputs.group }}"
           # Match the runner's vCPUs (auto) on hosted runners; but on large,
           # shared self-hosted runners fall back to 2 when left at 'auto' to
           # avoid oversubscribing (an explicit integer is always honored).

--- a/scripts/compute_affected_sublibraries.jl
+++ b/scripts/compute_affected_sublibraries.jl
@@ -51,6 +51,12 @@
 #
 # Output: JSON array of {group, version, runner, timeout, num_threads} objects
 #   for GitHub Actions matrix include.
+#
+# With the --projects flag the output is instead a JSON array of the affected
+# "lib/<pkg>" paths (the union of directly-changed and transitively-affected
+# sublibraries), for the project-model sublibrary CI which tests each via
+# `tests.yml` project=lib/<pkg> rather than GROUP dispatch. test_groups.toml
+# (versions/runner/timeout/threads/local_only) does not apply in that mode.
 
 using TOML
 
@@ -241,6 +247,15 @@ function json_value(v::Int)
     return print(v)
 end
 
+function print_projects(direct::Set{String}, transitive::Set{String})
+    print("[")
+    for (i, pkg) in enumerate(sort!(collect(union(direct, transitive))))
+        i > 1 && print(",")
+        print("\"lib/", pkg, "\"")
+    end
+    return println("]")
+end
+
 function print_json(entries)
     print("[")
     for (i, entry) in enumerate(entries)
@@ -271,6 +286,10 @@ function main()
 
     changed_files = split(read(stdin, String), '\n')
     direct, transitive = compute_affected(collect(String, changed_files), graph, reverse_deps)
+
+    if "--projects" in ARGS
+        return print_projects(direct, transitive)
+    end
 
     matrix = build_matrix(direct, transitive, lib_dir)
     return print_json(matrix)

--- a/scripts/compute_affected_sublibraries.jl
+++ b/scripts/compute_affected_sublibraries.jl
@@ -256,6 +256,54 @@ function print_projects(direct::Set{String}, transitive::Set{String})
     return println("]")
 end
 
+# Like build_matrix, but for the project model: one entry per affected
+# sublibrary × test group × version, carrying the lib/<pkg> project path and
+# the bare group name (passed to the sublibrary's runtests via the group env
+# var, e.g. ODEDIFFEQ_TEST_GROUP) rather than the GROUP-dispatch "pkg_group"
+# string. Same test_groups.toml semantics (versions/runner/timeout/threads/
+# local_only), downstream-only-on-v1 rule, and EXCLUDES as build_matrix.
+function build_projects_matrix(
+        direct::Set{String}, transitive::Set{String}, lib_dir::String
+    )
+    entries = []
+    for pkg in sort!(collect(union(direct, transitive)))
+        groups = load_test_groups(lib_dir, pkg)
+        is_downstream = pkg in transitive
+        for group_name in sort!(collect(keys(groups)))
+            config = groups[group_name]
+            is_downstream && config.local_only && continue
+            ci_group = group_name == "Core" ? pkg : "$(pkg)_$(group_name)"
+            versions = is_downstream ? [DOWNSTREAM_VERSION] : config.versions
+            for ver in versions
+                (ci_group, ver) in EXCLUDES && continue
+                push!(
+                    entries,
+                    (;
+                        project = "lib/$(pkg)", group = group_name, version = ver,
+                        runner = config.runner, timeout = config.timeout,
+                        num_threads = config.num_threads,
+                    )
+                )
+            end
+        end
+    end
+    return entries
+end
+
+function print_projects_matrix(entries)
+    print("[")
+    for (i, entry) in enumerate(entries)
+        i > 1 && print(",")
+        print(
+            "{\"project\":\"", entry.project, "\",\"group\":\"", entry.group,
+            "\",\"version\":\"", entry.version, "\",\"runner\":",
+        )
+        json_value(entry.runner)
+        print(",\"timeout\":", entry.timeout, ",\"num_threads\":", entry.num_threads, "}")
+    end
+    return println("]")
+end
+
 function print_json(entries)
     print("[")
     for (i, entry) in enumerate(entries)
@@ -286,6 +334,10 @@ function main()
 
     changed_files = split(read(stdin, String), '\n')
     direct, transitive = compute_affected(collect(String, changed_files), graph, reverse_deps)
+
+    if "--projects-matrix" in ARGS
+        return print_projects_matrix(build_projects_matrix(direct, transitive, lib_dir))
+    end
 
     if "--projects" in ARGS
         return print_projects(direct, transitive)


### PR DESCRIPTION
One inherited workflow for **all** monorepo sublibrary CI — dependency-graph change detection **and** the full per-sublibrary `test_groups.toml` matrix, so it serves everything from the small monorepos up to OrdinaryDiffEq.

**Caller** stays a thin `uses:` (+ optional knobs for repos like ODE):
```yaml
jobs:
  sublibraries:
    uses: SciML/.github/.github/workflows/sublibrary-project-tests.yml@v1
    # with:                                   # OrdinaryDiffEq
    #   group-env-name: ODEDIFFEQ_TEST_GROUP
    #   check-bounds: auto
    secrets: inherit
```

**Detection** (`compute_affected_sublibraries.jl --projects-matrix`): the changed sublibraries + their transitive reverse-deps, expanded into `{project, group, version, runner, timeout, num_threads}` per test group. Reuses `test_groups.toml` (multi-version, custom/GPU runners, timeout, num_threads, `local_only`), the downstream→v1 rule, and EXCLUDES. No `test_groups.toml` → default `Core[lts,1.11,1,pre]` + `QA[1]`. `test-all: true` forces the full matrix.

**Execution** is the project model: `tests.yml@v1` with `project: lib/X`, the group passed via `group-env-name` (default `GROUP`; ODE uses `ODEDIFFEQ_TEST_GROUP`). This is behaviorally equivalent to ODE's root-`runtests.jl` dispatcher (`Pkg.activate(lib/X)` + transitive `[sources]` develop + `withenv(ODEDIFFEQ_TEST_GROUP) Pkg.test`).

**tests.yml gains** (all defaults preserve existing callers): `runner` (JSON labels, e.g. self-hosted GPU), `timeout-minutes`, `check-bounds`, `allow-reresolve`, `group-env-name`.

**Verified locally** with `--projects-matrix` against OrdinaryDiffEq: GPU groups land on `[self-hosted,Linux,X64,gpu]` with `timeout:60`; Core spans `lts/1.11/1` (`pre` dropped by EXCLUDES for BDF); reverse-deps come in as downstream on `1`; no-toml sublibs get `Core[lts,1.11,1,pre]+QA[1]`. Existing group-matrix and `--projects` outputs unchanged.

Callers (need this merged + `v1` retag): BoundaryValueDiffEq#499, NonlinearSolve#954, Corleone#77, DataDrivenDiffEq#611, RecursiveArrayTools#605, LinearSolve#1006, NeuralLyapunov#187, DiffEqProblemLibrary#192, Optimization#1216 (+ OrdinaryDiffEq, pending).

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)