### PR TITLE
ci: add reusable docs-preview-cleanup.yml

### DIFF
--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,0 +1,47 @@
+name: "Reusable Doc Preview Cleanup Workflow"
+
+# Deletes a closed PR's Documenter preview from the docs branch (default
+# gh-pages) and squashes that branch's history to a single commit so it
+# doesn't grow without bound. Mirrors Documenter's documented DocPreviewCleanup.
+# The caller triggers on `pull_request: [closed]` and grants contents: write.
+
+on:
+  workflow_call:
+    inputs:
+      preview-branch:
+        description: "Branch the docs/previews live on."
+        default: "gh-pages"
+        required: false
+        type: string
+      preview-dir-root:
+        description: "Directory under which per-PR previews are stored (preview is <root>/PR<number>)."
+        default: "previews"
+        required: false
+        type: string
+
+jobs:
+  doc-preview-cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: "Checkout ${{ inputs.preview-branch }}"
+        uses: actions/checkout@v6
+        with:
+          ref: "${{ inputs.preview-branch }}"
+      - name: "Delete preview and squash history"
+        env:
+          PREVIEW_DIR: "${{ inputs.preview-dir-root }}/PR${{ github.event.number }}"
+          PREVIEW_BRANCH: "${{ inputs.preview-branch }}"
+        run: |
+          set -euo pipefail
+          if [ -d "$PREVIEW_DIR" ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git rm -rf "$PREVIEW_DIR"
+            git commit -m "delete preview for PR ${{ github.event.number }}"
+            git branch gh-pages-new "$(echo "delete history" | git commit-tree "HEAD^{tree}")"
+            git push --force origin "gh-pages-new:$PREVIEW_BRANCH"
+          else
+            echo "No preview directory $PREVIEW_DIR; nothing to clean up."
+          fi


### PR DESCRIPTION
Deletes a **closed PR's Documenter preview** from the docs branch (default `gh-pages`) and squashes that branch's history to a single commit so it doesn't grow unbounded — [Documenter's documented `DocPreviewCleanup`](https://documenter.juliadocs.org/stable/man/hosting/#Cleaning-up-gh-pages) as a reusable workflow. Inputs: `preview-branch` (default `gh-pages`), `preview-dir-root` (default `previews`).

**Caller** (`.github/workflows/DocPreviewCleanup.yml`):
```yaml
name: Doc Preview Cleanup
on:
  pull_request:
    types: [closed]
permissions:
  contents: write
jobs:
  cleanup:
    uses: SciML/.github/.github/workflows/docs-preview-cleanup.yml@v1
    secrets: inherit
```

`actionlint` + `shellcheck` clean.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)