### PR TITLE
ci(tests): apt-packages hook + force-latest-compatible-version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,6 +91,16 @@ on:
         default: "GROUP"
         required: false
         type: string
+      apt-packages:
+        description: "Space-separated apt packages to install before building/testing (for packages with system dependencies, e.g. R / Python / FEniCS wrappers). Linux runners only."
+        default: ""
+        required: false
+        type: string
+      force-latest-compatible-version:
+        description: "Value of julia-runtest's force_latest_compatible_version"
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   tests:
@@ -148,6 +158,12 @@ jobs:
             isempty(specs) || Pkg.develop(specs)
           end
 
+      - name: "Install system packages"
+        if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ inputs.apt-packages }}
+
       - uses: julia-actions/julia-buildpkg@v1
         if: "${{ inputs.buildpkg }}"
         with:
@@ -168,6 +184,7 @@ jobs:
           coverage: "${{ inputs.coverage }}"
           check_bounds: "${{ inputs.check-bounds }}"
           allow_reresolve: ${{ inputs.allow-reresolve }}
+          force_latest_compatible_version: ${{ inputs.force-latest-compatible-version }}
         env:
           # Match the runner's vCPUs (auto) on hosted runners; but on large,
           # shared self-hosted runners fall back to 2 when left at 'auto' to


### PR DESCRIPTION
Two new `tests.yml` inputs (both default to no-op, preserving current callers):

- **`apt-packages`** — space-separated apt packages installed (Linux runners) before build/test. Lets packages with system deps — the R/Python/FEniCS wrappers in #56 cat A (deSolveDiffEq.jl, FEniCS.jl, Pyomo.jl) — adopt the centralized `tests.yml` instead of a bespoke inline workflow, e.g. `with: { apt-packages: "python3-dev python3-pip" }`.
- **`force-latest-compatible-version`** — passthrough to `julia-runtest` (default `false`).

`actionlint` clean.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)