### PR TITLE
ci(downgrade): expose julia-downgrade-compat mode

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -23,6 +23,11 @@ on:
         default: "."
         required: false
         type: string
+      mode:
+        description: "julia-downgrade-compat mode: deps (direct), alldeps (deps+weakdeps), weakdeps, or forcedeps (strict lower-bound verification). Empty uses the action default."
+        default: ""
+        required: false
+        type: string
       allow-reresolve:
         description: "Allow Pkg to re-resolve (and thus relax) the downgraded environment when running tests"
         default: false
@@ -54,6 +59,7 @@ jobs:
         with:
           skip: "${{ inputs.skip }}"
           projects: "${{ inputs.projects }}"
+          mode: "${{ inputs.mode }}"
 
       - uses: julia-actions/julia-buildpkg@v1
 


### PR DESCRIPTION
Adds a `mode` input to `downgrade.yml`, forwarded to `julia-actions/julia-downgrade-compat`: `deps` (direct), `alldeps` (deps + weakdeps), `weakdeps`, or `forcedeps` (strict lower-bound verification). Empty = the action's default, so existing callers are unchanged. Useful for the downgrade re-enablement work in #56 (e.g. `forcedeps` to verify lower bounds are real).

`actionlint` clean.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)