### PR TITLE
ci(downgrade): default mode to "deps" (fix empty-mode regression)

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -29,8 +29,8 @@ on:
         required: false
         type: string
       mode:
-        description: "julia-downgrade-compat mode: deps (direct), alldeps (deps+weakdeps), weakdeps, or forcedeps (strict lower-bound verification). Empty uses the action default."
-        default: ""
+        description: "julia-downgrade-compat mode: deps (direct), alldeps (deps+weakdeps), weakdeps, or forcedeps (strict lower-bound verification). Empty maps to 'deps' (the action rejects an empty mode)."
+        default: "deps"
         required: false
         type: string
       allow-reresolve:
@@ -64,7 +64,7 @@ jobs:
         with:
           skip: "${{ inputs.skip }}"
           projects: "${{ inputs.projects }}"
-          mode: "${{ inputs.mode }}"
+          mode: "${{ inputs.mode != '' && inputs.mode || 'deps' }}"
 
       - uses: julia-actions/julia-buildpkg@v1
         with:


### PR DESCRIPTION
The empty-`mode` regression from #64 is still live on `@v1`: the merged #67 added only the `project` input, not the `mode` fix. `downgrade.yml` still has `mode` default `""` and passes `mode: "${{ inputs.mode }}"`, which `julia-downgrade-compat` rejects (`mode in valid_modes || error()`), so every caller without an explicit `mode` fails at the downgrade-compat step before tests run.

This sets the default to `deps` and maps an explicit empty string to `deps`.

After merge, **`v1` must be retagged** for callers to pick it up. Until then, callers can work around it by passing `mode: "deps"` explicitly.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)