### PR TITLE
ci: bump codecov/codecov-action v6 → v7

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -84,7 +84,7 @@ jobs:
           directories: "${{ inputs.coverage-directories }}"
 
       - name: "Report Coverage with Codecov"
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         if: "${{ inputs.coverage }}"
         with:
           files: lcov.info

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: "Report Coverage with Codecov"
         if: "${{ inputs.coverage }}"
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -197,7 +197,7 @@ jobs:
           directories: "${{ inputs.coverage-directories }}"
 
       - name: "Report Coverage with Codecov"
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         if: "${{ inputs.coverage }}"
         with:
           files: lcov.info


### PR DESCRIPTION
Bumps `codecov/codecov-action` from v6 to v7 in `tests.yml`, `downstream.yml`, and `documentation.yml`.

v7 is primarily a node24 bump (composite action); the `files` and `token` inputs are unchanged (verified against v7 `action.yml`), so the existing callers (`files: lcov.info`, `token: CODECOV_TOKEN`) work as-is — no caller changes needed.

After merge, **`v1` must be retagged** for consumers to pick it up.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)