### PR TITLE
ci(documentation): add runner input for GPU-queue doc builds

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,6 +31,11 @@ on:
         default: "ubuntu-latest"
         required: false
         type: string
+      runner:
+        description: "JSON-encoded runs-on value (string or array of labels, e.g. '[\"self-hosted\",\"Linux\",\"X64\",\"gpu\"]'). When non-empty it overrides self-hosted/os — use it to build docs on a GPU queue."
+        default: ""
+        required: false
+        type: string
       cache:
         description: "Use the julia-actions/cache action for caching"
         default: true
@@ -55,7 +60,7 @@ jobs:
   tests:
     name: "Build and Deploy Documentation"
     continue-on-error: ${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}
-    runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
+    runs-on: ${{ inputs.runner != '' && fromJson(inputs.runner) || (inputs.self-hosted && 'self-hosted' || inputs.os) }}
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Adds a `runner` input to `documentation.yml` (mirrors `tests.yml`): a JSON-encoded runs-on value (e.g. `["self-hosted","Linux","X64","gpu"]`) that overrides `self-hosted`/`os` when non-empty. This lets repos whose docs require a GPU build via the **central `documentation.yml@v1` caller on a GPU queue**, instead of a bespoke GPU.yml/ci.yml.

`runs-on` becomes `${{ inputs.runner != '' && fromJson(inputs.runner) || (inputs.self-hosted && 'self-hosted' || inputs.os) }}`. Backward-compatible (default `""` preserves current behavior).

After merge + `v1` retag, the GPU-docs repos (HighDimPDE, ModelingToolkit, Optimization, ReservoirComputing, SciMLSensitivity) can switch their bespoke doc builds to this caller with `runner: ...`.

> Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)