### PR TITLE
Downgrade workflows: always allow_reresolve=false, remove the input

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -33,11 +33,6 @@ on:
         default: "deps"
         required: false
         type: string
-      allow-reresolve:
-        description: "Allow Pkg to re-resolve (and thus relax) the downgraded environment when running tests"
-        default: false
-        required: false
-        type: boolean
       self-hosted:
         description: "Run the job on a self hosted machine"
         default: false
@@ -73,6 +68,6 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           project: "${{ inputs.project }}"
-          allow_reresolve: "${{ inputs.allow-reresolve }}"
+          allow_reresolve: false
         env:
           GROUP: "${{ inputs.group }}"

--- a/.github/workflows/sublibrary-downgrade.yml
+++ b/.github/workflows/sublibrary-downgrade.yml
@@ -27,11 +27,6 @@ on:
         default: ""
         required: false
         type: string
-      allow-reresolve:
-        description: "Allow the test environment to resolve transitive/test-only deps the downgrade step does not lock"
-        default: true
-        required: false
-        type: boolean
       group-env-name:
         description: "Optional env var name to set as the test group for each sublibrary (e.g. ODEDIFFEQ_TEST_GROUP)"
         default: ""
@@ -109,4 +104,4 @@ jobs:
       - uses: julia-actions/julia-runtest@v1
         with:
           project: ${{ matrix.project }}
-          allow_reresolve: ${{ inputs.allow-reresolve }}
+          allow_reresolve: false


### PR DESCRIPTION
## What

Make the centralized **downgrade** workflows always run with
`allow_reresolve: false`, with no way to override it.

- `downgrade.yml`: removed the `allow-reresolve` `workflow_call` input and
  hardcoded `allow_reresolve: false` on the `julia-actions/julia-runtest` step.
- `sublibrary-downgrade.yml`: removed the `allow-reresolve` input (its default
  was `true`) and hardcoded `allow_reresolve: false` on the per-sublibrary
  `julia-actions/julia-runtest` step.

Re-resolving relaxes the downgraded environment, which defeats the purpose of a
downgrade-compat test. Per policy we always want `false`, so the knob is gone.

`actionlint` passes on both files.

## ⚠️ This is a BREAKING `workflow_call` change — merge order matters

Removing a `workflow_call` input means any caller that still passes
`allow-reresolve:` will fail with an "invalid input" error the moment `@v1` is
retagged. **This PR plus all the caller-cleanup PRs below must merge first, and
only THEN should `v1` be retagged.** If `v1` is retagged before the callers are
cleaned up, those callers break.

Behavior note: most callers already passed `allow-reresolve: false`, so for them
this is a no-op. A handful passed `allow-reresolve: true` (mostly
`DowngradeSublibraries.yml` callers, plus `OrdinaryDiffEq.jl`/`ReservoirComputing.jl`/`SBMLToolkit.jl`/`DiffEqFlux.jl`);
for those the downgrade run will now be strict (`false`) instead of re-resolving.
That is the intended outcome of this policy change, but it is a real behavior
change for those repos and may surface previously-hidden floor conflicts.

## Caller-cleanup PRs (must merge before retagging v1)

Open campaign downgrade PRs — line removal pushed to the existing branch:
- SciML/IRKGaussLegendre.jl#119
- SciML/DiffEqBayes.jl#381
- SciML/NeuralPDE.jl#1066
- SciML/DiffEqCallbacks.jl#307
- SciML/DiffEqFlux.jl#1025 (was passing `true`)
- SciML/ModelingToolkitNeuralNets.jl#126
- SciML/DASSL.jl#95 and SciML/JumpProcesses.jl#599 referenced the term only in
  comments and pass no input — no change needed.

Fresh `drop-allow-reresolve-input` draft PRs (one per caller repo) are listed in
a follow-up comment on this PR.

## Follow-up (not in this PR — only workflow YAMLs were edited)

`README.md` still documents an `allow-reresolve` input for both `downgrade.yml`
(reference table) and `sublibrary-downgrade.yml` (reference table). Those two
rows are now stale and should be removed in a docs follow-up. The copy-paste
example blocks do not pass the input, so no example breaks.

---

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>
Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
