### PR TITLE
Default version matrix -> Core [lts,1,pre], QA [lts,1]

### DIFF
--- a/scripts/compute_affected_sublibraries.jl
+++ b/scripts/compute_affected_sublibraries.jl
@@ -11,10 +11,10 @@
 # Each sublibrary can optionally define test groups in test/test_groups.toml:
 #
 #   [Core]
-#   versions = ["lts", "1.11", "1", "pre"]
+#   versions = ["lts", "1", "pre"]
 #
 #   [QA]
-#   versions = ["1"]
+#   versions = ["lts", "1"]
 #
 #   [GPU]
 #   versions = ["1"]
@@ -34,8 +34,8 @@
 #                 runs whenever any file under lib/<this-pkg>/ is edited.
 #
 # If no test/test_groups.toml exists, the default is:
-#   Core on ["lts", "1.11", "1", "pre"]
-#   QA on ["1"]
+#   Core on ["lts", "1", "pre"]
+#   QA on ["lts", "1"]
 #
 # A group that needs test-only deps beyond the sublibrary's [targets].test list should
 # carry an isolated environment at test/<group>/Project.toml that runtests.jl activates
@@ -61,8 +61,8 @@
 using TOML
 
 const DEFAULT_TEST_GROUPS = Dict(
-    "Core" => ["lts", "1.11", "1", "pre"],
-    "QA" => ["1"],
+    "Core" => ["lts", "1", "pre"],
+    "QA" => ["lts", "1"],
 )
 
 function build_dependency_graph(lib_dir::String)


### PR DESCRIPTION
## Summary

Aligns the **default test version matrix** — the one applied when a monorepo sublibrary has **no `test/test_groups.toml`** — with the org version convention.

`scripts/compute_affected_sublibraries.jl` defines `DEFAULT_TEST_GROUPS`, which `load_test_groups` falls back to when a sublibrary ships no `test_groups.toml`. It was still on the old form. This PR moves it to the standard sets:

| group | before | after |
|---|---|---|
| `Core` (and any standard/default group) | `["lts","1.11","1","pre"]` | `["lts","1","pre"]` |
| `QA` | `["1"]` | `["lts","1"]` |
| `GPU` | (not in default) | unchanged — stays `["1"]`, only ever set via explicit `test_groups.toml` |

The pinned `"1.11"` middle version is dropped from `Core`; `QA` now also runs on `lts`. Only the no-`test_groups.toml` default values change — the dependency-graph / reverse-dep / matrix-emission logic is untouched, and a sublibrary that ships its own `test_groups.toml` is unaffected.

## Files changed

- `scripts/compute_affected_sublibraries.jl`
  - `DEFAULT_TEST_GROUPS` const: `Core => ["lts","1","pre"]`, `QA => ["lts","1"]`.
  - Header doc comment + illustrative `test_groups.toml` example updated to the same convention.

`Monorepo.md` (§5, "default when there's no `test_groups.toml`") and `README.md` already documented this exact target default, so no doc edits were needed there — this PR brings the script in line with the docs.

## Validation (static only)

- Script parses cleanly (`Meta.parseall`, 38 top-level forms) — no instantiate / precompile / test run.
- New `DEFAULT_TEST_GROUPS` literal verified: `Core == ["lts","1","pre"]`, `QA == ["lts","1"]`, no `GPU` key.

Ignore until reviewed by @ChrisRackauckas.