### PR TITLE
feat(grouped-tests): root test_groups.toml → CI matrix (closes #76); fix #75 self-test regression

### DIFF
--- a/.github/workflows/grouped-tests.yml
+++ b/.github/workflows/grouped-tests.yml
@@ -1,0 +1,112 @@
+name: "Reusable Grouped Tests Workflow (test_groups.toml)"
+
+# Runs a package's OWN test groups, declared once in test/test_groups.toml, via
+# the reusable tests.yml workflow (project: '.'). Each group runs on every Julia
+# version it lists, carrying its per-group runner / timeout / num_threads /
+# continue_on_error, dispatched through a group env var (default GROUP) that the
+# package's runtests.jl reads. This replaces a hand-maintained group × version
+# matrix embedded in the caller's CI.yml: the matrix lives in test_groups.toml
+# and CI.yml becomes a thin caller. The matrix is computed by
+# scripts/compute_affected_sublibraries.jl --root-matrix.
+#
+# Works for monorepo ROOTS and ordinary single packages alike (no lib/ needed).
+# When the repo has no test/test_groups.toml, the default is a single "Core"
+# group (the whole suite) on ["lts", "1", "pre"]. The root matrix is NOT
+# diff-filtered -- every group runs on every push/PR (unlike the per-sublibrary
+# sublibrary-project-tests.yml, which is incremental).
+#
+# Caller (per repo) supplies its branch triggers + concurrency:
+#
+#   jobs:
+#     tests:
+#       uses: SciML/.github/.github/workflows/grouped-tests.yml@v1
+#       # with:                                  # OrdinaryDiffEq, e.g.
+#       #   group-env-name: ODEDIFFEQ_TEST_GROUP
+#       #   check-bounds: auto
+#       secrets: inherit
+
+on:
+  workflow_call:
+    inputs:
+      group-env-name:
+        description: "Environment variable name the package's runtests.jl reads its group from (default GROUP)"
+        default: "GROUP"
+        required: false
+        type: string
+      check-bounds:
+        description: "Value of julia-runtest's check_bounds (yes/no/auto) for each group"
+        default: "yes"
+        required: false
+        type: string
+      allow-reresolve:
+        description: "Value of julia-runtest's allow_reresolve for each group"
+        default: true
+        required: false
+        type: boolean
+      coverage:
+        description: "Collect and upload code coverage"
+        default: true
+        required: false
+        type: boolean
+      coverage-directories:
+        description: "Comma-separated directories the processcoverage step scans"
+        default: "src,ext"
+        required: false
+        type: string
+      apt-packages:
+        description: "Space-separated apt packages to install before building/testing (e.g. for R / Python / FEniCS wrappers). Linux runners only."
+        default: ""
+        required: false
+        type: string
+      dotgithub-ref:
+        description: "Ref of SciML/.github to source the matrix-computation script from"
+        default: "v1"
+        required: false
+        type: string
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.compute.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - name: "Checkout SciML/.github for the matrix script"
+        uses: actions/checkout@v6
+        with:
+          repository: SciML/.github
+          ref: "${{ inputs.dotgithub-ref }}"
+          path: .sciml-dotgithub
+      - uses: julia-actions/setup-julia@v3
+        with:
+          version: "1"
+      - name: "Compute root test-group matrix from test/test_groups.toml"
+        id: compute
+        run: |
+          MATRIX=$(julia .sciml-dotgithub/scripts/compute_affected_sublibraries.jl . --root-matrix)
+          echo "Matrix: $MATRIX"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  test:
+    needs: detect
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.detect.outputs.matrix) }}
+    name: "${{ matrix.group }} (julia ${{ matrix.version }})"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      project: "."
+      group: "${{ matrix.group }}"
+      group-env-name: "${{ inputs.group-env-name }}"
+      julia-version: "${{ matrix.version }}"
+      runner: ${{ toJson(matrix.runner) }}
+      timeout-minutes: ${{ matrix.timeout }}
+      num-threads: "${{ matrix.num_threads }}"
+      continue-on-error: ${{ matrix.continue_on_error }}
+      check-bounds: "${{ inputs.check-bounds }}"
+      allow-reresolve: ${{ inputs.allow-reresolve }}
+      coverage: ${{ inputs.coverage }}
+      coverage-directories: "${{ inputs.coverage-directories }}"
+      apt-packages: "${{ inputs.apt-packages }}"
+    secrets: "inherit"

--- a/.github/workflows/sublibrary-project-tests.yml
+++ b/.github/workflows/sublibrary-project-tests.yml
@@ -12,7 +12,7 @@ name: "Reusable Sublibrary CI (project model)"
 # timeout/num_threads/local_only), exactly like sublibrary-tests.yml -- but run
 # in the project model: tests.yml with project=lib/<name> and the group passed
 # via group-env-name (e.g. ODEDIFFEQ_TEST_GROUP). Sublibraries with no
-# test_groups.toml get the default Core on [lts,1.11,1,pre] + QA on [1].
+# test_groups.toml get the default Core on [lts,1,pre] + QA on [lts,1].
 # tests.yml transitively git-develops the sublibrary's in-repo [sources], so no
 # root runtests.jl GROUP dispatcher is needed.
 #

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Two things live here:
   - [Monorepo structure](#monorepo-structure) — full layout spec in [Monorepo.md](Monorepo.md)
   - [How sublibrary tests run](#how-sublibrary-tests-run)
   - [`test_groups.toml`](#test_groupstoml)
+  - [`grouped-tests.yml` (root matrix)](#grouped-testsyml--declare-the-root-test-matrix-in-test_groupstoml)
   - [Dependency-graph change detection](#dependency-graph-change-detection)
   - [`sublibrary-project-tests.yml`](#sublibrary-project-testsyml)
   - [`sublibrary-downgrade.yml`](#sublibrary-downgradeyml)
@@ -458,8 +459,15 @@ come from each sublib's `test_groups.toml` (below).
 
 ### `test_groups.toml`
 
-Either model expands each affected sublibrary into a matrix defined by an
-optional `lib/<name>/test/test_groups.toml`:
+The same file format declares test groups in **two** places:
+
+- **`lib/<name>/test/test_groups.toml`** — a sublibrary's groups, expanded by
+  the (diff-filtered) sublibrary CI below.
+- **`test/test_groups.toml`** (repo root) — the **root** package's own groups,
+  expanded by [`grouped-tests.yml`](#grouped-testsyml) so the root `CI.yml` is a
+  thin caller instead of a hand-maintained matrix. Works for non-monorepos too.
+
+A sublibrary file looks like:
 
 ```toml
 [Core]
@@ -482,10 +490,13 @@ Per-group fields:
 | `runner` | `"ubuntu-latest"` | `runs-on` string or label array (e.g. a GPU self-hosted runner). |
 | `timeout` | `120` | Job timeout in minutes. |
 | `num_threads` | `1` | `JULIA_NUM_THREADS`. |
-| `local_only` | `false` | When `true`, skip this group if the sublibrary is in the matrix only because an upstream dependency changed (not its own files). For groups too expensive to run on every transitive rebuild. |
+| `local_only` | `false` | When `true`, skip this group if the sublibrary is in the matrix only because an upstream dependency changed (not its own files). For groups too expensive to run on every transitive rebuild. *(Sublibrary matrix only; not meaningful at the root.)* |
+| `continue_on_error` | `false` | When `true`, a failing job in this group doesn't fail the run (maps to `tests.yml`'s `continue-on-error`). Used for non-fatal root groups such as OrdinaryDiffEq's `Downstream`. |
 
-**Default when there's no `test_groups.toml`:** `Core` on `["lts","1","pre"]`
-+ `QA` on `["lts","1"]`. (See [Monorepo.md](Monorepo.md#5-test_groupstoml) for the
+**Default when there's no `test_groups.toml`:** for a sublibrary, `Core` on
+`["lts","1","pre"]` + `QA` on `["lts","1"]`; for the **root** matrix
+(`grouped-tests.yml`), a single `Core` group (the whole suite) on
+`["lts","1","pre"]`. (See [Monorepo.md](Monorepo.md#5-test_groupstoml) for the
 version-set rollout.)
 
 The group name reaches the sublibrary's `runtests.jl` through an env var. In the
@@ -501,6 +512,79 @@ if GROUP == "All" || GROUP == "QA"
     # Aqua / JET / allocation tests
 end
 ```
+
+### `grouped-tests.yml` — declare the root test matrix in `test_groups.toml`
+
+A package's **root** test groups can be declared once in a root
+`test/test_groups.toml` and run via `grouped-tests.yml`, instead of
+hand-maintaining a `group × version` matrix in each repo's `CI.yml`. The root
+`CI.yml` becomes a thin caller:
+
+```yaml
+# .github/workflows/CI.yml
+name: CI
+on:
+  pull_request:
+    branches: [master]
+    paths-ignore: ['docs/**']
+  push:
+    branches: [master]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+jobs:
+  tests:
+    uses: "SciML/.github/.github/workflows/grouped-tests.yml@v1"
+    secrets: "inherit"
+```
+
+and `test/test_groups.toml` carries the matrix (per-group `versions` express
+what would otherwise be a base matrix plus `exclude:`/`include:` rows):
+
+```toml
+[InterfaceI]
+versions = ["lts", "1", "pre"]
+
+[AD]
+versions = ["lts"]                              # this group only on lts
+
+[QA]
+versions = ["lts", "1"]
+
+[Downstream]
+versions = ["lts", "1", "pre"]
+continue_on_error = true                        # non-fatal group
+
+[GPU]
+versions = ["1"]
+runner = ["self-hosted", "Linux", "X64", "gpu"]
+```
+
+`grouped-tests.yml` runs `compute_affected_sublibraries.jl --root-matrix` to
+turn that into the job matrix, then runs each `group × version` cell via
+`tests.yml` (`project: '.'`), dispatching the group through `group-env-name`
+(default `GROUP`) — the same env var the package's `runtests.jl` already reads.
+Unlike the per-sublibrary matrix it is **not** diff-filtered: the root package
+runs all of its groups on every push/PR.
+
+**Not monorepo-only.** Any single package can adopt it: with no
+`test/test_groups.toml` the default is a single `Core` group (the whole suite)
+on `["lts","1","pre"]`, so a non-monorepo gets the standard version matrix from
+a near-zero-line `CI.yml`, and can split into groups later.
+
+| Input | Type | Default | Description |
+|---|---|---|---|
+| `group-env-name` | string | `"GROUP"` | Env var the package's `runtests.jl` reads its group from (OrdinaryDiffEq uses `ODEDIFFEQ_TEST_GROUP`). |
+| `check-bounds` | string | `"yes"` | `julia-runtest` `check_bounds` per group. |
+| `allow-reresolve` | boolean | `true` | `julia-runtest` `allow_reresolve`. |
+| `coverage` | boolean | `true` | Collect & upload coverage. |
+| `coverage-directories` | string | `"src,ext"` | Coverage dirs. |
+| `apt-packages` | string | `""` | System packages to install (Linux). |
+| `dotgithub-ref` | string | `"v1"` | Ref of `SciML/.github` to source the matrix script from. |
+
+> A monorepo therefore has **two** test workflows: `grouped-tests.yml` for the
+> root package's own groups, and `sublibrary-project-tests.yml` for the
+> (incremental) `lib/<name>` sublibraries.
 
 ### Dependency-graph change detection
 
@@ -521,6 +605,7 @@ The script's output modes:
 |---|---|---|
 | `… <repo> --projects-matrix` | `[{project, group, version, runner, timeout, num_threads}, …]` | `sublibrary-project-tests.yml` |
 | `… <repo> --projects` | `["lib/A", "lib/B", …]` | simple path listing |
+| `… <repo> --root-matrix` | `[{group, version, runner, timeout, num_threads, continue_on_error}, …]` from the **root** `test/test_groups.toml` (no diff filter, no `lib/` required) | `grouped-tests.yml` |
 
 ### `sublibrary-project-tests.yml`
 

--- a/scripts/compute_affected_sublibraries.jl
+++ b/scripts/compute_affected_sublibraries.jl
@@ -57,6 +57,16 @@
 # sublibraries), for the project-model sublibrary CI which tests each via
 # `tests.yml` project=lib/<pkg> rather than GROUP dispatch. test_groups.toml
 # (versions/runner/timeout/threads/local_only) does not apply in that mode.
+#
+# With the --root-matrix flag the output is the ROOT package's group matrix,
+# read from <repo>/test/test_groups.toml (NOT under lib/), as a JSON array of
+# {group, version, runner, timeout, num_threads, continue_on_error}. This is not
+# diff-filtered (the root package runs all its groups every push/PR) and needs
+# no lib/ directory, so ordinary single packages can use it too. When no
+# test/test_groups.toml exists the default is a single "Core" group on
+# ["lts", "1", "pre"]. Consumed by the reusable grouped-tests.yml so a repo's
+# root CI.yml is a thin caller instead of a hand-maintained matrix. Usage:
+#   julia compute_affected_sublibraries.jl /path/to/repo --root-matrix
 
 using TOML
 
@@ -133,26 +143,50 @@ struct TestGroupConfig
     timeout::Int
     num_threads::Int
     local_only::Bool
+    continue_on_error::Bool
+end
+
+function parse_test_group(config::AbstractDict)
+    versions = convert(Vector{String}, config["versions"])
+    runner_raw = get(config, "runner", "ubuntu-latest")
+    runner = runner_raw isa Vector ? convert(Vector{String}, runner_raw) : runner_raw::String
+    timeout = Int(get(config, "timeout", 120))
+    num_threads = Int(get(config, "num_threads", 1))
+    local_only = Bool(get(config, "local_only", false))
+    continue_on_error = Bool(get(config, "continue_on_error", false))
+    return TestGroupConfig(versions, runner, timeout, num_threads, local_only, continue_on_error)
 end
 
 function load_test_groups(lib_dir::String, pkg::String)
     groups_file = joinpath(lib_dir, pkg, "test", "test_groups.toml")
     if isfile(groups_file)
         toml = TOML.parsefile(groups_file)
-        groups = Dict{String, TestGroupConfig}()
-        for (name, config) in toml
-            versions = convert(Vector{String}, config["versions"])
-            runner_raw = get(config, "runner", "ubuntu-latest")
-            runner = runner_raw isa Vector ? convert(Vector{String}, runner_raw) : runner_raw::String
-            timeout = Int(get(config, "timeout", 120))
-            num_threads = Int(get(config, "num_threads", 1))
-            local_only = Bool(get(config, "local_only", false))
-            groups[name] = TestGroupConfig(versions, runner, timeout, num_threads, local_only)
-        end
-        return groups
+        return Dict{String, TestGroupConfig}(name => parse_test_group(config) for (name, config) in toml)
     end
     return Dict{String, TestGroupConfig}(
-        k => TestGroupConfig(v, "ubuntu-latest", 120, 1, false) for (k, v) in DEFAULT_TEST_GROUPS
+        k => TestGroupConfig(v, "ubuntu-latest", 120, 1, false, false) for (k, v) in DEFAULT_TEST_GROUPS
+    )
+end
+
+# The root package's own test groups (test/test_groups.toml at the repo root,
+# NOT under lib/). Unlike the sublibrary matrix this is not diff-filtered: the
+# root package runs all of its groups on every push/PR. Consumed by the
+# reusable grouped-tests.yml so a monorepo root -- or any single package --
+# declares its group x version matrix once in test_groups.toml and keeps CI.yml
+# a thin caller, instead of hand-maintaining the matrix in YAML. When no
+# test/test_groups.toml exists, defaults to a single "Core" group (the whole
+# suite) on the standard version set.
+const DEFAULT_ROOT_GROUPS = Dict("Core" => ["lts", "1", "pre"])
+
+function load_root_test_groups(repo_root::String)
+    groups_file = joinpath(repo_root, "test", "test_groups.toml")
+    if isfile(groups_file)
+        toml = TOML.parsefile(groups_file)
+        groups = Dict{String, TestGroupConfig}(name => parse_test_group(config) for (name, config) in toml)
+        isempty(groups) || return groups
+    end
+    return Dict{String, TestGroupConfig}(
+        k => TestGroupConfig(v, "ubuntu-latest", 120, 1, false, false) for (k, v) in DEFAULT_ROOT_GROUPS
     )
 end
 
@@ -315,6 +349,43 @@ function print_json(entries)
     return println("]")
 end
 
+# Root-package matrix: every group × every version it lists, with no diff
+# filtering (the root package runs all its groups on every push/PR). Carries
+# continue_on_error so a non-fatal group (e.g. OrdinaryDiffEq's Downstream) maps
+# to tests.yml's continue-on-error input.
+function build_root_matrix(repo_root::String)
+    groups = load_root_test_groups(repo_root)
+    entries = []
+    for group_name in sort!(collect(keys(groups)))
+        config = groups[group_name]
+        for ver in config.versions
+            push!(
+                entries,
+                (;
+                    group = group_name, version = ver, runner = config.runner,
+                    timeout = config.timeout, num_threads = config.num_threads,
+                    continue_on_error = config.continue_on_error,
+                )
+            )
+        end
+    end
+    return entries
+end
+
+function print_root_matrix(entries)
+    print("[")
+    for (i, entry) in enumerate(entries)
+        i > 1 && print(",")
+        print("{\"group\":\"", entry.group, "\",\"version\":\"", entry.version, "\",\"runner\":")
+        json_value(entry.runner)
+        print(
+            ",\"timeout\":", entry.timeout, ",\"num_threads\":", entry.num_threads,
+            ",\"continue_on_error\":", entry.continue_on_error ? "true" : "false", "}",
+        )
+    end
+    return println("]")
+end
+
 function main()
     if length(ARGS) < 1
         println(stderr, "Usage: julia $(PROGRAM_FILE) <repo_root>")
@@ -322,6 +393,14 @@ function main()
     end
 
     repo_root = ARGS[1]
+
+    # Root-package group matrix from <repo>/test/test_groups.toml. Independent of
+    # the sublibrary dependency graph, so it works for ordinary single packages
+    # too (no lib/ required) -- handle it before the lib/ check.
+    if "--root-matrix" in ARGS
+        return print_root_matrix(build_root_matrix(repo_root))
+    end
+
     lib_dir = joinpath(repo_root, "lib")
 
     if !isdir(lib_dir)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -82,10 +82,10 @@ end
     @testset "projects-matrix: default groups + downstream→v1" begin
         direct, trans = compute_affected(["lib/A/src/A.jl"], graph, rev)
         m = build_projects_matrix(direct, trans, lib)
-        # A is directly changed: default Core on lts,1.11,1,pre + QA on 1
+        # A is directly changed: default Core on lts,1,pre + QA on lts,1
         a = filter(e -> e.project == "lib/A", m)
         @test Set((e.group, e.version) for e in a) ==
-              Set([("Core", "lts"), ("Core", "1.11"), ("Core", "1"), ("Core", "pre"), ("QA", "1")])
+              Set([("Core", "lts"), ("Core", "1"), ("Core", "pre"), ("QA", "lts"), ("QA", "1")])
         # B and C are downstream: version "1" only
         for p in ("lib/B", "lib/C")
             ds = filter(e -> e.project == p, m)
@@ -169,4 +169,84 @@ end
     # empty input -> []
     out2 = read(pipeline(IOBuffer("README.md\n"), `$(Base.julia_cmd()) $SCRIPT $root --projects-matrix`), String)
     @test strip(out2) == "[]"
+end
+
+@testset "root matrix: build_root_matrix (defaults, per-group fields, continue_on_error)" begin
+    d = mktempdir()
+    # No test/test_groups.toml -> single Core group on the standard set.
+    @test Set((e.group, e.version) for e in build_root_matrix(d)) ==
+          Set([("Core", "lts"), ("Core", "1"), ("Core", "pre")])
+    @test all(e -> e.continue_on_error == false, build_root_matrix(d))
+
+    mkpath(joinpath(d, "test"))
+    write(
+        joinpath(d, "test", "test_groups.toml"), """
+        [Core]
+        versions = ["lts", "1", "pre"]
+
+        [QA]
+        versions = ["lts", "1"]
+
+        [AD]
+        versions = ["lts"]
+
+        [Downstream]
+        versions = ["lts", "1", "pre"]
+        continue_on_error = true
+
+        [GPU]
+        versions = ["1"]
+        runner = ["self-hosted", "Linux", "X64", "gpu"]
+        timeout = 200
+        num_threads = 4
+        """
+    )
+    m = build_root_matrix(d)
+    cells = Set((e.group, e.version) for e in m)
+    @test ("AD", "1") ∉ cells && ("AD", "pre") ∉ cells && ("AD", "lts") in cells
+    @test ("QA", "pre") ∉ cells && ("QA", "lts") in cells && ("QA", "1") in cells
+    # continue_on_error rides only on the Downstream group.
+    @test all(e -> e.continue_on_error, filter(e -> e.group == "Downstream", m))
+    @test all(e -> !e.continue_on_error, filter(e -> e.group != "Downstream", m))
+    gpu = only(filter(e -> e.group == "GPU", m))
+    @test gpu.runner == ["self-hosted", "Linux", "X64", "gpu"]
+    @test gpu.timeout == 200 && gpu.num_threads == 4
+end
+
+@testset "root matrix faithfully reproduces OrdinaryDiffEq's embedded matrix" begin
+    # ODE's root CI.yml is 17 groups × [lts,1,pre] minus excludes (AD->lts only,
+    # QA->lts/1, ODEInterfaceRegression->lts only). Per-group `versions`
+    # expresses the same 46 cells, which is the migration this enables.
+    base = [
+        "InterfaceI", "InterfaceII", "InterfaceIII", "InterfaceIV", "InterfaceV",
+        "Integrators_I", "Integrators_II", "AlgConvergence_I", "AlgConvergence_II",
+        "AlgConvergence_III", "ModelingToolkit", "Downstream", "Regression_I", "Regression_II",
+    ]
+    d = mktempdir()
+    mkpath(joinpath(d, "test"))
+    io = IOBuffer()
+    for g in base
+        println(io, "[$g]\nversions = [\"lts\", \"1\", \"pre\"]\n")
+    end
+    println(io, "[AD]\nversions = [\"lts\"]\n")
+    println(io, "[QA]\nversions = [\"lts\", \"1\"]\n")
+    println(io, "[ODEInterfaceRegression]\nversions = [\"lts\"]\n")
+    write(joinpath(d, "test", "test_groups.toml"), String(take!(io)))
+
+    cells = Set((e.group, e.version) for e in build_root_matrix(d))
+    groups17 = vcat(base, ["AD", "QA", "ODEInterfaceRegression"])
+    expected = Set((g, v) for g in groups17 for v in ["lts", "1", "pre"])
+    for ex in [("AD", "1"), ("AD", "pre"), ("QA", "pre"), ("ODEInterfaceRegression", "1"), ("ODEInterfaceRegression", "pre")]
+        delete!(expected, ex)
+    end
+    @test cells == expected
+    @test length(cells) == 46
+end
+
+@testset "--root-matrix CLI (no lib/ required) + JSON shape" begin
+    d = mktempdir()  # deliberately NO lib/ directory
+    out = read(pipeline(IOBuffer(""), `$(Base.julia_cmd()) $SCRIPT $d --root-matrix`), String)
+    @test occursin("\"group\":\"Core\"", out)
+    @test occursin("\"continue_on_error\":false", out)
+    @test startswith(strip(out), "[") && endswith(strip(out), "]")
 end


### PR DESCRIPTION
Implements #76 — let a monorepo **root** (or any single package) declare its `group × version` matrix once in a root `test/test_groups.toml`, run via a new reusable **`grouped-tests.yml`**, so `CI.yml` becomes a thin caller instead of a hand-maintained matrix.

## What's here
- **`scripts/compute_affected_sublibraries.jl`** — new `--root-matrix` mode: reads `<repo>/test/test_groups.toml` (no diff filter, **no `lib/` required** → works for non-monorepos), emits `{group, version, runner, timeout, num_threads, continue_on_error}`. Adds the `continue_on_error` per-group field (maps to `tests.yml`'s `continue-on-error`; for non-fatal groups like ODE's `Downstream`). Default when absent: a single `Core` group on `[lts,1,pre]`.
- **`.github/workflows/grouped-tests.yml`** — new reusable workflow: `detect` runs `--root-matrix`, `test` fans out to `tests.yml@v1` (`project: '.'`) per cell, dispatching the group via `group-env-name`. Mirrors `sublibrary-project-tests.yml`'s proven passthrough.
- **Additive / backward compatible** — existing callers and the sublibrary JSON output are unchanged.
- **Fixes the #75 regression**: the default-groups self-test still expected the old `[lts,1.11,1,pre]`/`[1]` matrix, so `script-tests` went red on `master` after #75 merged. Updated the expectation + two stale comments. (`v1` currently ships this red test — this greens it.)
- **Tests**: `build_root_matrix` defaults/fields/`continue_on_error`, a **faithful 46-cell reproduction of OrdinaryDiffEq's embedded root matrix**, and a `--root-matrix` CLI test. Verified locally: all 50 pass; `actionlint` clean on the new workflow.
- **README** documents the model, `grouped-tests.yml`, the `continue_on_error` field, and the new output mode.

## After merge + `v1` retag
Migrate each monorepo's root `CI.yml` to the thin caller + author its root `test/test_groups.toml` (ODE first as reference; the 46-cell test shows the translation). Non-monorepos can opt in for a near-zero-line `CI.yml`.

_Ignore until reviewed by @ChrisRackauckas._