### PR TITLE
feat(grouped-tests): optional per-group `os` matrix axis

### DIFF
--- a/.github/workflows/grouped-tests.yml
+++ b/.github/workflows/grouped-tests.yml
@@ -2,9 +2,10 @@ name: "Reusable Grouped Tests Workflow (test_groups.toml)"
 
 # Runs a package's OWN test groups, declared once in test/test_groups.toml, via
 # the reusable tests.yml workflow (project: '.'). Each group runs on every Julia
-# version it lists, carrying its per-group runner / timeout / num_threads /
-# continue_on_error, dispatched through a group env var (default GROUP) that the
-# package's runtests.jl reads. This replaces a hand-maintained group × version
+# version it lists (and, if the group sets an `os` list, once per OS), carrying
+# its per-group runner / timeout / num_threads / continue_on_error, dispatched
+# through a group env var (default GROUP) that the package's runtests.jl reads.
+# This replaces a hand-maintained group × version (× os)
 # matrix embedded in the caller's CI.yml: the matrix lives in test_groups.toml
 # and CI.yml becomes a thin caller. The matrix is computed by
 # scripts/compute_affected_sublibraries.jl --root-matrix.
@@ -93,7 +94,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.detect.outputs.matrix) }}
-    name: "${{ matrix.group }} (julia ${{ matrix.version }})"
+    name: "${{ matrix.group }} (julia ${{ matrix.version }}, ${{ join(matrix.runner, ' ') }})"
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       project: "."

--- a/README.md
+++ b/README.md
@@ -488,6 +488,7 @@ Per-group fields:
 |---|---|---|
 | `versions` | — | Julia versions to run this group on. |
 | `runner` | `"ubuntu-latest"` | `runs-on` string or label array (e.g. a GPU self-hosted runner). |
+| `os` | — | *(Root matrix only.)* Array of OS runners for an **OS matrix** — the group runs once per OS (e.g. `["ubuntu-latest","windows-latest","macos-latest"]`), each cell's `runs-on` being that OS. Empty → use `runner`. Don't combine with a custom `runner`; if both are set, the OS axis wins. |
 | `timeout` | `120` | Job timeout in minutes. |
 | `num_threads` | `1` | `JULIA_NUM_THREADS`. |
 | `local_only` | `false` | When `true`, skip this group if the sublibrary is in the matrix only because an upstream dependency changed (not its own files). For groups too expensive to run on every transitive rebuild. *(Sublibrary matrix only; not meaningful at the root.)* |
@@ -558,10 +559,14 @@ continue_on_error = true                        # non-fatal group
 [GPU]
 versions = ["1"]
 runner = ["self-hosted", "Linux", "X64", "gpu"]
+
+[Core]
+versions = ["lts", "1"]
+os = ["ubuntu-latest", "windows-latest", "macos-latest"]   # OS matrix: runs once per OS
 ```
 
 `grouped-tests.yml` runs `compute_affected_sublibraries.jl --root-matrix` to
-turn that into the job matrix, then runs each `group × version` cell via
+turn that into the job matrix, then runs each `group × version × os` cell via
 `tests.yml` (`project: '.'`), dispatching the group through `group-env-name`
 (default `GROUP`) — the same env var the package's `runtests.jl` already reads.
 Unlike the per-sublibrary matrix it is **not** diff-filtered: the root package

--- a/scripts/compute_affected_sublibraries.jl
+++ b/scripts/compute_affected_sublibraries.jl
@@ -22,6 +22,10 @@
 #
 # Optional fields per group:
 #   runner      — string or array of labels (default: "ubuntu-latest")
+#   os          — array of OS runners for an OS matrix (root matrix only; the
+#                 group runs once per OS, e.g. ["ubuntu-latest","windows-latest",
+#                 "macos-latest"]). Empty -> use `runner`. Don't combine with a
+#                 custom `runner`; if both set, the OS axis wins.
 #   timeout     — integer, job timeout in minutes (default: 120)
 #   num_threads — integer, JULIA_NUM_THREADS (default: 1)
 #   local_only  — boolean (default: false). When true, the group is skipped
@@ -144,6 +148,7 @@ struct TestGroupConfig
     num_threads::Int
     local_only::Bool
     continue_on_error::Bool
+    os::Vector{String}  # root matrix only: OS axis (group runs once per os); empty = use `runner`
 end
 
 function parse_test_group(config::AbstractDict)
@@ -154,7 +159,8 @@ function parse_test_group(config::AbstractDict)
     num_threads = Int(get(config, "num_threads", 1))
     local_only = Bool(get(config, "local_only", false))
     continue_on_error = Bool(get(config, "continue_on_error", false))
-    return TestGroupConfig(versions, runner, timeout, num_threads, local_only, continue_on_error)
+    os = convert(Vector{String}, get(config, "os", String[]))
+    return TestGroupConfig(versions, runner, timeout, num_threads, local_only, continue_on_error, os)
 end
 
 function load_test_groups(lib_dir::String, pkg::String)
@@ -164,7 +170,7 @@ function load_test_groups(lib_dir::String, pkg::String)
         return Dict{String, TestGroupConfig}(name => parse_test_group(config) for (name, config) in toml)
     end
     return Dict{String, TestGroupConfig}(
-        k => TestGroupConfig(v, "ubuntu-latest", 120, 1, false, false) for (k, v) in DEFAULT_TEST_GROUPS
+        k => TestGroupConfig(v, "ubuntu-latest", 120, 1, false, false, String[]) for (k, v) in DEFAULT_TEST_GROUPS
     )
 end
 
@@ -186,7 +192,7 @@ function load_root_test_groups(repo_root::String)
         isempty(groups) || return groups
     end
     return Dict{String, TestGroupConfig}(
-        k => TestGroupConfig(v, "ubuntu-latest", 120, 1, false, false) for (k, v) in DEFAULT_ROOT_GROUPS
+        k => TestGroupConfig(v, "ubuntu-latest", 120, 1, false, false, String[]) for (k, v) in DEFAULT_ROOT_GROUPS
     )
 end
 
@@ -349,24 +355,32 @@ function print_json(entries)
     return println("]")
 end
 
-# Root-package matrix: every group × every version it lists, with no diff
-# filtering (the root package runs all its groups on every push/PR). Carries
-# continue_on_error so a non-fatal group (e.g. OrdinaryDiffEq's Downstream) maps
-# to tests.yml's continue-on-error input.
+# Root-package matrix: every group × every version it lists × every OS it lists,
+# with no diff filtering (the root package runs all its groups on every
+# push/PR). Carries continue_on_error so a non-fatal group (e.g. OrdinaryDiffEq's
+# Downstream) maps to tests.yml's continue-on-error input. The OS axis: a group
+# with `os = ["ubuntu-latest", "windows-latest", ...]` runs once per OS (each
+# cell's runner is that OS string); otherwise the group's `runner` is used (a
+# string like "ubuntu-latest" or a custom self-hosted label array, e.g. GPU).
+# `os` and a custom `runner` are not meant to be combined; if both are set, the
+# OS axis wins.
 function build_root_matrix(repo_root::String)
     groups = load_root_test_groups(repo_root)
     entries = []
     for group_name in sort!(collect(keys(groups)))
         config = groups[group_name]
+        runners = isempty(config.os) ? Any[config.runner] : Any[o for o in config.os]
         for ver in config.versions
-            push!(
-                entries,
-                (;
-                    group = group_name, version = ver, runner = config.runner,
-                    timeout = config.timeout, num_threads = config.num_threads,
-                    continue_on_error = config.continue_on_error,
+            for runner in runners
+                push!(
+                    entries,
+                    (;
+                        group = group_name, version = ver, runner = runner,
+                        timeout = config.timeout, num_threads = config.num_threads,
+                        continue_on_error = config.continue_on_error,
+                    )
                 )
-            )
+            end
         end
     end
     return entries

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -213,6 +213,37 @@ end
     @test gpu.timeout == 200 && gpu.num_threads == 4
 end
 
+@testset "root matrix: OS axis (group × version × os)" begin
+    d = mktempdir()
+    mkpath(joinpath(d, "test"))
+    write(
+        joinpath(d, "test", "test_groups.toml"), """
+        [Core]
+        versions = ["lts", "1"]
+        os = ["ubuntu-latest", "windows-latest", "macos-latest"]
+
+        [QA]
+        versions = ["1"]
+
+        [GPU]
+        versions = ["1"]
+        runner = ["self-hosted", "Linux", "X64", "gpu"]
+        """
+    )
+    m = build_root_matrix(d)
+    # Core: 2 versions × 3 OSes = 6 cells; each cell's runner is the OS string.
+    core = filter(e -> e.group == "Core", m)
+    @test length(core) == 6
+    @test Set((e.version, e.runner) for e in core) ==
+          Set((v, o) for v in ["lts", "1"] for o in ["ubuntu-latest", "windows-latest", "macos-latest"])
+    # QA: no os -> single default ubuntu runner.
+    qa = filter(e -> e.group == "QA", m)
+    @test length(qa) == 1 && only(qa).runner == "ubuntu-latest"
+    # GPU: custom runner, no OS fan-out.
+    gpu = filter(e -> e.group == "GPU", m)
+    @test length(gpu) == 1 && only(gpu).runner == ["self-hosted", "Linux", "X64", "gpu"]
+end
+
 @testset "root matrix faithfully reproduces OrdinaryDiffEq's embedded matrix" begin
     # ODE's root CI.yml is 17 groups × [lts,1,pre] minus excludes (AD->lts only,
     # QA->lts/1, ODEInterfaceRegression->lts only). Per-group `versions`


### PR DESCRIPTION
Follow-up to #78. Adds an optional **OS-matrix axis** to the root `test_groups.toml` model so multi-OS packages can adopt `grouped-tests.yml` uniformly (the gap noted during the canonicalization rollout planning).

A group may declare:
```toml
[Core]
versions = ["lts", "1"]
os = ["ubuntu-latest", "windows-latest", "macos-latest"]
```
and the root matrix fans out **group × version × os** — each cell's `runs-on` is that OS. When `os` is absent the group's `runner` is used exactly as before (a string, or a custom label array like a GPU self-hosted runner); if both are set, the OS axis wins.

- `compute_affected_sublibraries.jl`: `os` field on `TestGroupConfig` + parse; OS fan-out in `build_root_matrix`. **Sublibrary builders ignore `os` → no behavior change there.**
- `grouped-tests.yml`: job name now includes the runner so OS cells are distinct in the UI.
- Tests (4 new OS-axis assertions), README (fields table + example + header). Verified locally: all tests pass, `actionlint` clean.

Backward compatible — packages without an `os` field are unaffected.

_Ignore until reviewed by @ChrisRackauckas._