### PR TITLE
tests.yml: set test group env with shell: bash so it takes effect on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -173,7 +173,10 @@ jobs:
         # Set the group under a configurable env var name so sublibraries that
         # read e.g. ODEDIFFEQ_TEST_GROUP work the same as the default GROUP. The
         # name must be dynamic, which the env: map can't express, so write it to
-        # $GITHUB_ENV here.
+        # $GITHUB_ENV here. shell: bash is required: the default shell on
+        # Windows is pwsh, where "$GITHUB_ENV" does not expand, so the env var
+        # is silently never set and Windows jobs run the default group instead.
+        shell: bash
         run: echo "${{ inputs.group-env-name }}=${{ inputs.group }}" >> "$GITHUB_ENV"
 
       - name: "Run tests ${{ inputs.self-hosted && '' || format('on {0}', inputs.os) }} with Julia v${{ inputs.julia-version }}"


### PR DESCRIPTION
> [!IMPORTANT]
> This PR should be ignored until reviewed by @ChrisRackauckas.

## Bug

The "Set test group env" step in `tests.yml`:

```yaml
run: echo "${{ inputs.group-env-name }}=${{ inputs.group }}" >> "$GITHUB_ENV"
```

has no explicit `shell:`, so on Windows runners it executes under the default pwsh, where `"$GITHUB_ENV"` (bash syntax) does not expand. The env var is silently never set, and Windows matrix jobs run the package's default test group (typically `All`/Core) instead of the requested one.

## Evidence

In SciML/DataInterpolationsND.jl scheduled run [27210697854](https://github.com/SciML/DataInterpolationsND.jl/actions/runs/27210697854):

- `QA (julia lts, ubuntu-latest)` logs show `GROUP: QA` in the julia-runtest env and run the Aqua/ExplicitImports/JET QA suite (which currently fails — fix in SciML/DataInterpolationsND.jl#70).
- `QA (julia lts, windows-latest)` logs show the step running under `pwsh.EXE`, no `GROUP` in the julia-runtest env, and the **Core** test summaries (Interpolations/Derivatives/DataInterpolations/Interface) with no Aqua output — yet the job reports success.

So Windows QA jobs across any repo using `grouped-tests.yml`/`tests.yml` with groups are silently running the wrong group, masking real failures.

## Fix

Add `shell: bash` to the step. bash is already a hard requirement of julia-runtest's own composite steps on Windows runners (its steps run under `C:\Program Files\Git\bin\bash.EXE`), so this adds no new dependency, including for self-hosted runners that already run julia-runtest.

Not verified by running the reusable workflow end-to-end (it only takes effect once tagged); verification basis is the job logs above showing the pwsh execution and the missing env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)