### PR TITLE
downgrade: disable force_latest_compatible_version in runtest

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -91,5 +91,10 @@ jobs:
         with:
           project: "${{ inputs.project }}"
           allow_reresolve: false
+          # 'auto' flips to true on Dependabot/CompatHelper PRs, which demands the
+          # latest compatible versions — the exact opposite of a downgraded manifest —
+          # and fails resolution (e.g. "empty intersection between X@min and project
+          # compatibility latest"). Downgrade tests must keep the minimum versions.
+          force_latest_compatible_version: false
         env:
           GROUP: "${{ inputs.group }}"


### PR DESCRIPTION
## Problem

The reusable downgrade workflow calls `julia-actions/julia-runtest@v1` without setting `force_latest_compatible_version`, so it defaults to `auto` — which flips to `true` when the PR author is Dependabot or CompatHelper. Forcing the latest compatible versions is the exact opposite of what a downgrade test does (the manifest is resolved to minimum versions first), and since the workflow also sets `allow_reresolve: false`, resolution fails outright.

Observed on https://github.com/SciML/CatalystNetworkAnalysis.jl/pull/68 (Downgrade job):

```
[ Info: This is a Dependabot/CompatHelper job, so `force_latest_compatible_version` has been set to `true`
...
ERROR: LoadError: empty intersection between CDDLib@0.9.4 and project compatibility 0.10
```

CDDLib compat is `"0.9.4, 0.10"`; the downgrade action pinned the manifest to 0.9.4, then runtest demanded the latest compatible (0.10) with reresolve disabled → empty intersection. This affects the Downgrade job on every Dependabot/CompatHelper PR in every repo consuming this workflow.

## Fix

Pin `force_latest_compatible_version: false` on the runtest step. Downgrade tests must always test the minimum-version manifest regardless of who opened the PR.

Note: consumers reference `downgrade.yml@v1`, so the `v1` tag needs to be moved after merge for this to take effect.

**This PR should be ignored until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)