### PR TITLE
Skip missing directories in coverage processing instead of erroring

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -191,14 +191,35 @@ jobs:
           # avoid oversubscribing (an explicit integer is always honored).
           JULIA_NUM_THREADS: "${{ (inputs.self-hosted && inputs.num-threads == 'auto') && '2' || inputs.num-threads }}"
 
-      - uses: julia-actions/julia-processcoverage@v1
+      - name: "Filter coverage directories to those that exist"
+        # julia-processcoverage hard-errors on directories that don't exist
+        # (e.g. lib/<name>/ext for sublibraries without extensions), so drop
+        # the missing entries here and skip coverage entirely if none remain.
+        id: coverage-dirs
         if: "${{ inputs.coverage }}"
+        shell: bash
+        env:
+          COVERAGE_DIRECTORIES: "${{ inputs.coverage-directories }}"
+        run: |
+          existing=""
+          IFS=',' read -ra requested <<< "$COVERAGE_DIRECTORIES"
+          for dir in "${requested[@]}"; do
+            if [ -d "$dir" ]; then
+              existing="${existing:+$existing,}$dir"
+            else
+              echo "Skipping missing coverage directory: $dir"
+            fi
+          done
+          echo "directories=$existing" >> "$GITHUB_OUTPUT"
+
+      - uses: julia-actions/julia-processcoverage@v1
+        if: "${{ inputs.coverage && steps.coverage-dirs.outputs.directories != '' }}"
         with:
-          directories: "${{ inputs.coverage-directories }}"
+          directories: "${{ steps.coverage-dirs.outputs.directories }}"
 
       - name: "Report Coverage with Codecov"
         uses: codecov/codecov-action@v7
-        if: "${{ inputs.coverage }}"
+        if: "${{ inputs.coverage && steps.coverage-dirs.outputs.directories != '' }}"
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
> [!NOTE]
> Please ignore this PR until it has been reviewed by @ChrisRackauckas.

## Bug

`sublibrary-project-tests.yml` unconditionally passes

```yaml
coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
```

to the reusable `tests.yml` workflow, which feeds it straight into `julia-actions/julia-processcoverage@v1`. That action hard-errors when any listed directory does not exist, so every sublibrary-ci job for a sublibrary **without** an `ext/` directory fails at the coverage step even though the tests passed.

Example from SciML/OrdinaryDiffEq.jl (`lib/OrdinaryDiffEqRosenbrock`): https://github.com/SciML/OrdinaryDiffEq.jl/actions/runs/27249537353/job/80470821662 — after `Testing OrdinaryDiffEqRosenbrock tests passed`, the "Process coverage" step fails with:

```
Error: ERROR: directory "lib/OrdinaryDiffEqRosenbrock/ext" not found!
```

The `tests.yml` default of `coverage-directories: "src,ext"` has the same problem for ext-less root packages.

## Fix

In `tests.yml`, immediately before the `julia-processcoverage` step, a small bash step filters the comma-separated directories list down to the entries that actually exist (splitting via `IFS=',' read -ra`, with the input passed through `env:` rather than interpolated into the script) and publishes the filtered list via `$GITHUB_OUTPUT`. `julia-processcoverage` and the Codecov upload then run on the filtered list, and are skipped entirely when no directories remain (rather than being handed an empty list).

This keeps `ext` coverage for sublibraries that do have an `ext/` directory — nothing is dropped from the requested list, only entries that don't exist on disk. Since `grouped-tests.yml` and `sublibrary-project-tests.yml` both route coverage through `tests.yml`, one fix covers all consumers.

## Validation

I could not execute the reusable workflow itself locally (it requires a `workflow_call` from a real repository run). Instead:

- `actionlint` passes on the modified `tests.yml` (and on `sublibrary-project-tests.yml`).
- `python3 -c "import yaml; yaml.safe_load(...)"` parses the file cleanly.
- The filter snippet was run locally under `bash -e` against four cases: `src` present / `ext` missing (outputs `lib/Foo/src`), both present (outputs both unchanged), all missing (outputs empty → steps skipped), and empty input (outputs empty). All exited 0 with the expected `directories=` output.

## Note for release

Consumers (e.g. OrdinaryDiffEq.jl) pin this workflow at `@v1`, so the `v1` tag will need to be moved (or a new tag cut) after merge for the fix to reach them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)