### PR TITLE
tests/grouped-tests: optional container input (restore FEniCS-style containerized CI)

### DIFF
--- a/.github/workflows/grouped-tests.yml
+++ b/.github/workflows/grouped-tests.yml
@@ -59,6 +59,11 @@ on:
         default: ""
         required: false
         type: string
+      container:
+        description: "Docker container image to run each test job in, e.g. for Python-stack packages (empty string = no container)"
+        default: ""
+        required: false
+        type: string
       dotgithub-ref:
         description: "Ref of SciML/.github to source the matrix-computation script from"
         default: "v1"
@@ -110,4 +115,5 @@ jobs:
       coverage: ${{ inputs.coverage }}
       coverage-directories: "${{ inputs.coverage-directories }}"
       apt-packages: "${{ inputs.apt-packages }}"
+      container: "${{ inputs.container }}"
     secrets: "inherit"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,6 +96,11 @@ on:
         default: ""
         required: false
         type: string
+      container:
+        description: "Docker container image to run the job in, e.g. for Python-stack packages (empty string = no container)"
+        default: ""
+        required: false
+        type: string
       force-latest-compatible-version:
         description: "Value of julia-runtest's force_latest_compatible_version"
         default: false
@@ -107,6 +112,7 @@ jobs:
     name: "Tests${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
     continue-on-error: ${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}
     runs-on: ${{ inputs.runner != '' && fromJson(inputs.runner) || (inputs.self-hosted && 'self-hosted' || inputs.os) }}
+    container: ${{ inputs.container }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
     steps:
       - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ tested via `project: lib/X` without a hand-written develop step.
 | `self-hosted` | boolean | `false` | Run on a self-hosted runner. |
 | `os` | string | `"ubuntu-latest"` | Runner OS (ignored when self-hosted). |
 | `runner` | string | `""` | JSON-encoded `runs-on` (string or label array, e.g. `'["self-hosted","Linux","X64","gpu"]'`). When non-empty, overrides `self-hosted`/`os`. |
+| `container` | string | `""` | Docker container image to run the job in (e.g. `cmhyett/julia-fenics:latest` for Python-stack packages). Empty = no container. |
 | `timeout-minutes` | number | `360` | Job timeout. |
 | `cache` | boolean | `true` | Use `julia-actions/cache`. |
 | `buildpkg` | boolean | `true` | Run `julia-actions/julia-buildpkg`. |
@@ -597,6 +598,7 @@ a near-zero-line `CI.yml`, and can split into groups later.
 | `coverage` | boolean | `true` | Collect & upload coverage. |
 | `coverage-directories` | string | `"src,ext"` | Coverage dirs. |
 | `apt-packages` | string | `""` | System packages to install (Linux). |
+| `container` | string | `""` | Docker container image each test job runs in (e.g. `cmhyett/julia-fenics:latest`). Empty = no container. |
 | `dotgithub-ref` | string | `"v1"` | Ref of `SciML/.github` to source the matrix script from. |
 
 > A monorepo therefore has **two** test workflows: `grouped-tests.yml` for the


### PR DESCRIPTION
## What

Adds an optional `container` input (string, default `""`) to the reusable test workflows:

- **`tests.yml`**: new `container` input, applied as `container: ${{ inputs.container }}` on the `tests` job. An empty string evaluates to "no container" per GitHub Actions semantics, so existing callers are unaffected.
- **`grouped-tests.yml`**: same input, passed through to `tests.yml` for every matrix job.
- **README**: documented the new input in both workflow tables.

## Why

Packages wrapping Python stacks need their test jobs to run inside a prebuilt Docker image. FEniCS.jl's pre-conversion CI ran in `container: cmhyett/julia-fenics:latest` (the FEniCS Python stack); the grouped-tests conversion (SciML/FEniCS.jl#154) dropped the container, so every Core job fails because the FEniCS Python libraries are missing. This input restores that capability through the centralized workflows.

## Verification

- `actionlint` clean on both modified workflows.
- Both files parse as valid YAML; `container` input present with empty-string default.

After merge this needs a `v1` retag for `@v1` callers (FEniCS.jl#154 depends on it).

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)