### PR TITLE
downgrade: auto-skip [sources] path deps (fix Unsatisfiable on monorepo/path-dep downgrade)

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -73,6 +73,31 @@ jobs:
           ')"
           echo "Julia stdlibs: $stdlibs"
           effective="$stdlibs"
+          # Any dep declared in a project's `[sources]` table is satisfied
+          # in-tree by a path/url checkout (not the registry), so its version is
+          # whatever that checkout is. julia-downgrade-compat would rewrite its
+          # `[compat]` to `=<floor>`, which the in-tree version can't satisfy ->
+          # "Unsatisfiable requirements ... no versions left". Skip every
+          # `[sources]` dep name across all `projects` dirs.
+          IFS=',' read -ra _dirs <<< "${{ inputs.projects }}"
+          for dir in "${_dirs[@]}"; do
+              dir="$(echo "$dir" | xargs)"   # trim surrounding whitespace
+              [ -n "$dir" ] || continue
+              f="$dir/Project.toml"
+              if [ ! -f "$f" ]; then
+                  echo "No Project.toml in '$dir', skipping [sources] scan"
+                  continue
+              fi
+              names="$(julia --startup-file=no -e '
+                using TOML
+                src = get(TOML.parsefile(ARGS[1]), "sources", Dict())
+                println(join(collect(keys(src)), ","))
+              ' "$f")"
+              if [ -n "$names" ]; then
+                  echo "[sources] deps in $dir: $names"
+                  effective="$effective,$names"
+              fi
+          done
           [ -n "${{ inputs.skip }}" ] && effective="$effective,${{ inputs.skip }}"
           echo "Effective downgrade skip: $effective"
           echo "EFFECTIVE_SKIP=$effective" >> "$GITHUB_ENV"

--- a/.github/workflows/sublibrary-downgrade.yml
+++ b/.github/workflows/sublibrary-downgrade.yml
@@ -125,6 +125,27 @@ jobs:
           echo "In-repo sublibraries: $sublibs"
           effective="$STDLIB_SKIP"
           [ -n "$sublibs" ] && effective="$effective,$sublibs"
+          # The sublibrary being downgraded (matrix.project) may itself declare a
+          # `[sources]` table pointing at path/url deps (e.g. a sibling lib). Such
+          # deps are satisfied in-tree by a checkout, not the registry, so
+          # julia-downgrade-compat rewriting their `[compat]` to `=<floor>` yields
+          # "Unsatisfiable requirements ... no versions left". The lib/* basename
+          # skip above only covers deps whose source name matches a lib dir name;
+          # parse the actual `[sources]` keys to also catch url/aliased sources.
+          src_f="${{ matrix.project }}/Project.toml"
+          if [ -f "$src_f" ]; then
+              src_names="$(julia --startup-file=no -e '
+                using TOML
+                src = get(TOML.parsefile(ARGS[1]), "sources", Dict())
+                println(join(collect(keys(src)), ","))
+              ' "$src_f")"
+              if [ -n "$src_names" ]; then
+                  echo "[sources] deps in ${{ matrix.project }}: $src_names"
+                  effective="$effective,$src_names"
+              fi
+          else
+              echo "No Project.toml at $src_f, skipping [sources] scan"
+          fi
           [ -n "${{ inputs.skip }}" ] && effective="$effective,${{ inputs.skip }}"
           echo "Effective downgrade skip: $effective"
           echo "EFFECTIVE_SKIP=$effective" >> "$GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ to catch under-specified `[compat]` lower bounds.
 |---|---|---|---|
 | `julia-version` | string | `"lts"` | Julia version: the LTS alias (currently 1.10), tracking the LTS as it advances (the minimum-supported floor; see note). |
 | `group` | string | `""` | Test group. |
-| `skip` | string | `""` | **Additional** deps to skip when downgrading, beyond the auto-included Julia stdlibs (see note). |
+| `skip` | string | `""` | **Additional** deps to skip when downgrading, beyond the auto-included Julia stdlibs and any `[sources]` path/url deps (see note). |
 | `projects` | string | `"."` | Comma-separated project dirs to downgrade. |
 | `project` | string | `"@."` | `--project` for build/test (a workspace submodule or `lib/X`); default tests the repo root. |
 | `self-hosted` / `os` | | `false` / `ubuntu-latest` | Runner selection. |
@@ -240,10 +240,12 @@ jobs:
 
 > Downgrade is **strict**: the reusable workflow hardcodes `allow_reresolve:
 > false` and exposes **no `allow-reresolve` input**. The `skip` list is
-> **auto-populated** with all Julia stdlibs, so callers no longer hand-list
-> `Pkg,TOML,Statistics,…` — pass `skip` only for genuinely-extra deps. The
-> caller-facing `julia-version` default is **`"lts"`**, the LTS alias (currently
-> 1.10), tracking the LTS as it advances.
+> **auto-populated** with all Julia stdlibs **and every dep declared in a
+> project's `[sources]` table** (path/url deps are satisfied in-tree, not from
+> the registry, so they must never be downgrade-pinned), so callers no longer
+> hand-list `Pkg,TOML,Statistics,…` or their path deps — pass `skip` only for
+> genuinely-extra deps. The caller-facing `julia-version` default is **`"lts"`**,
+> the LTS alias (currently 1.10), tracking the LTS as it advances.
 > (Auto-skip and the `lts` default land via
 > [SciML/.github #73](https://github.com/SciML/.github/pull/73); strict
 > `allow_reresolve: false` is already in effect.)
@@ -667,7 +669,7 @@ Downgrade-compat tests for each `lib/*` sublibrary.
 | Input | Type | Default | Description |
 |---|---|---|---|
 | `julia-version` | string | `"lts"` | Julia version: the LTS alias (currently 1.10), tracking the LTS as it advances (the minimum-supported floor; see note). |
-| `skip` | string | `""` | **Additional** deps to skip when downgrading, beyond the auto-included Julia stdlibs and in-repo `lib/*` sublibrary names (see note). |
+| `skip` | string | `""` | **Additional** deps to skip when downgrading, beyond the auto-included Julia stdlibs, in-repo `lib/*` sublibrary names, and the sublibrary's own `[sources]` path/url deps (see note). |
 | `projects` | string | `""` | Explicit space-separated `lib/*` paths; empty = auto-discover all. |
 | `exclude` | string | `""` | Space-separated sublibrary names to exclude from auto-discovery. |
 | `group-env-name` | string | `""` | Optional group env var name (e.g. `ODEDIFFEQ_TEST_GROUP`). |
@@ -682,11 +684,13 @@ jobs:
 
 > Downgrade is **strict**: the reusable workflow hardcodes `allow_reresolve:
 > false` and exposes **no `allow-reresolve` input**. The `skip` list is
-> **auto-populated** with all Julia stdlibs plus the in-repo `lib/*` sublibrary
-> names (path-`[sources]` packages must not be downgrade-pinned), so callers no
-> longer hand-list them — pass `skip` only for genuinely-extra deps. The
-> caller-facing `julia-version` default is **`"lts"`**, the LTS alias (currently
-> 1.10), tracking the LTS as it advances.
+> **auto-populated** with all Julia stdlibs, the in-repo `lib/*` sublibrary
+> names, **and every dep declared in the downgraded sublibrary's `[sources]`
+> table** (path/url packages are satisfied in-tree, not from the registry, so
+> they must never be downgrade-pinned), so callers no longer hand-list them —
+> pass `skip` only for genuinely-extra deps. The caller-facing `julia-version`
+> default is **`"lts"`**, the LTS alias (currently 1.10), tracking the LTS as it
+> advances.
 > (Auto-skip and the `lts` default land via
 > [SciML/.github #73](https://github.com/SciML/.github/pull/73); strict
 > `allow_reresolve: false` is already in effect.)


### PR DESCRIPTION
## Problem

When a `Project.toml` declares a `[sources]` table (path/url deps — common in
monorepos and `lib/*` workspaces), that dep is satisfied **in-tree** by the
checkout, not from the registry. `julia-actions/julia-downgrade-compat` rewrites
every dep's `[compat]` to `=<floor>`, but the in-tree path version is whatever
the checkout is — so the pin can't be satisfied and resolution dies with:

```
ERROR: Unsatisfiable requirements detected for package X:
  ... no versions left
```

before any test runs. This is the org-wide `[sources]`+`[extras]`+`[compat]`
downgrade breakage.

## Fix

Treat every `[sources]` dep the same way stdlibs are already treated: **never
downgrade-pin them**, by unioning their names into the effective skip list.

### `downgrade.yml`
In the existing **"Compute effective downgrade skip list"** step, for each dir
in `projects` (comma-separated, default `.`), parse `<dir>/Project.toml`'s
`[sources]` keys and union them into `EFFECTIVE_SKIP`:

```julia
using TOML
get(TOML.parsefile(joinpath(dir, "Project.toml")), "sources", Dict()) |> keys
```

Missing `Project.toml` / missing `[sources]` section are guarded; the found
source names are echoed. `EFFECTIVE_SKIP` is now `stdlibs ∪ [sources] ∪ inputs.skip`.

### `sublibrary-downgrade.yml`
Its skip step already unions stdlibs + in-repo `lib/*` directory basenames.
Added: parse the **downgraded sublibrary's own** `[sources]` keys
(`matrix.project/Project.toml`) and union them in. The basename skip only
matches deps whose source name equals a `lib/` dir name; parsing the actual
`[sources]` keys also catches url-/aliased sources.

### `README.md`
Documents that `[sources]` path/url deps are auto-skipped for both workflows.

## Local verification

- `actionlint` clean on both workflows.
- Unit-tested the parse logic against throwaway `Project.toml` fixtures (with
  `[sources]`, without `[sources]`, a missing dir, and a sublibrary's own
  `[sources]`). Extracted-step-body output:

```
[sources] deps in proj_a: MyURLDep,MyPathDep
No Project.toml in 'no_such_dir', skipping [sources] scan
Effective downgrade skip: Pkg,TOML,Statistics,MyURLDep,MyPathDep,ExtraSkipDep

[sources] deps in lib/SubLib: SiblingLib
Effective downgrade skip: Pkg,TOML,Statistics,SubLib,SiblingLib
```

## NOTE

`v1` must be **retagged after merge** for callers (which pin `@v1`) to pick this
up.

Ignore until reviewed by @ChrisRackauckas.