### PR TITLE
downgrade: auto-skip [sources] deps + resolve julia-version alias to numeric

### DIFF
--- a/.github/workflows/sublibrary-downgrade.yml
+++ b/.github/workflows/sublibrary-downgrade.yml
@@ -90,6 +90,8 @@ jobs:
       - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ inputs.julia-version }}
+      - name: "Resolve numeric Julia version for downgrade-compat"
+        run: echo "JULIA_MM=$(julia --startup-file=no -e 'print(VERSION.major, ".", VERSION.minor)')" >> "$GITHUB_ENV"
       - name: "Set sublibrary test group"
         if: "${{ inputs.group-env-name != '' }}"
         run: echo "${{ inputs.group-env-name }}=${{ inputs.group-env-value }}" >> "$GITHUB_ENV"
@@ -153,7 +155,7 @@ jobs:
         with:
           projects: ${{ matrix.project }}
           skip: ${{ env.EFFECTIVE_SKIP }}
-          julia_version: ${{ inputs.julia-version }}
+          julia_version: ${{ env.JULIA_MM }}
       - uses: julia-actions/julia-buildpkg@v1
         with:
           project: ${{ matrix.project }}


### PR DESCRIPTION
## Summary

This branch carries two related fixes to the reusable downgrade workflows. The first (`[sources]` auto-skip) already landed on `master` via #87; this PR adds the second (alias→numeric) on the same branch, so the effective diff here is the alias fix.

### 1. Auto-skip `[sources]` deps (already merged via #87)
Deps declared in a project's `[sources]` table are satisfied in-tree by a path/url checkout, not the registry. `julia-downgrade-compat` rewriting their `[compat]` to `=<floor>` yields "Unsatisfiable requirements ... no versions left" on monorepo/path-dep downgrades. Both `downgrade.yml` and `sublibrary-downgrade.yml` now parse each project's `[sources]` keys and union them into the effective skip list.

### 2. Resolve `julia-version` alias to numeric for julia-downgrade-compat (this commit)
`sublibrary-downgrade.yml` forwarded the channel ALIAS `julia-version` (e.g. `lts`) straight into `julia-actions/julia-downgrade-compat@v2`'s `julia_version:` input. The action passes that to its resolver as `--julia=lts`, which is rejected:

```
[ERROR] Invalid compat version spec: --julia=lts
```

Fix: after `julia-actions/setup-julia@v3` installs Julia, capture the actual installed `major.minor` into `JULIA_MM` and pass `julia_version: ${{ env.JULIA_MM }}` to the downgrade-compat step. So `lts`/`1`/`pre` resolve to the installed numeric (e.g. `1.10`), a valid compat spec.

`downgrade.yml` (single-package) does NOT forward `julia_version:` to julia-downgrade-compat — it lets the action infer from installed Julia (already numeric) — so it was left unchanged.

## Validation
- `actionlint` passes on both workflow files (exit 0).
- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`.

NOTE: v1 must be retagged after merge for callers to pick this up. Ignore until reviewed by @ChrisRackauckas.