### PR TITLE
downgrade/sublibrary-downgrade: add apt-packages + container inputs

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -43,11 +43,22 @@ on:
         default: "ubuntu-latest"
         required: false
         type: string
+      apt-packages:
+        description: "Space-separated apt packages to install before building/testing (Linux only)."
+        default: ""
+        required: false
+        type: string
+      container:
+        description: "Docker container image to run the job in, e.g. for Python-stack packages (empty string = no container)"
+        default: ""
+        required: false
+        type: string
 
 jobs:
   downgrade:
     name: "Downgrade Tests${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
     runs-on: "${{ inputs.self-hosted && 'self-hosted' || inputs.os }}"
+    container: ${{ inputs.container }}
     steps:
       - uses: actions/checkout@v6
 
@@ -107,6 +118,12 @@ jobs:
           skip: "${{ env.EFFECTIVE_SKIP }}"
           projects: "${{ inputs.projects }}"
           mode: "${{ inputs.mode != '' && inputs.mode || 'deps' }}"
+
+      - name: "Install system packages"
+        if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ inputs.apt-packages }}
 
       - uses: julia-actions/julia-buildpkg@v1
         with:

--- a/.github/workflows/sublibrary-downgrade.yml
+++ b/.github/workflows/sublibrary-downgrade.yml
@@ -37,6 +37,16 @@ on:
         default: ""
         required: false
         type: string
+      apt-packages:
+        description: "Space-separated apt packages to install before building/testing (Linux only)."
+        default: ""
+        required: false
+        type: string
+      container:
+        description: "Docker container image to run the job in, e.g. for Python-stack packages (empty string = no container)"
+        default: ""
+        required: false
+        type: string
 
 jobs:
   discover:
@@ -81,6 +91,7 @@ jobs:
     needs: discover
     if: needs.discover.outputs.has_any == 'true'
     runs-on: ubuntu-latest
+    container: ${{ inputs.container }}
     strategy:
       fail-fast: false
       matrix:
@@ -156,6 +167,11 @@ jobs:
           projects: ${{ matrix.project }}
           skip: ${{ env.EFFECTIVE_SKIP }}
           julia_version: ${{ env.JULIA_MM }}
+      - name: "Install system packages"
+        if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ${{ inputs.apt-packages }}
       - uses: julia-actions/julia-buildpkg@v1
         with:
           project: ${{ matrix.project }}

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ to catch under-specified `[compat]` lower bounds.
 | `projects` | string | `"."` | Comma-separated project dirs to downgrade. |
 | `project` | string | `"@."` | `--project` for build/test (a workspace submodule or `lib/X`); default tests the repo root. |
 | `self-hosted` / `os` | | `false` / `ubuntu-latest` | Runner selection. |
+| `apt-packages` | string | `""` | Space-separated apt packages to install before building/testing (Linux only). |
+| `container` | string | `""` | Docker container image to run the job in (e.g. `cmhyett/julia-fenics:latest` for Python-stack packages). Empty = no container. |
 
 ```yaml
 jobs:
@@ -674,6 +676,8 @@ Downgrade-compat tests for each `lib/*` sublibrary.
 | `exclude` | string | `""` | Space-separated sublibrary names to exclude from auto-discovery. |
 | `group-env-name` | string | `""` | Optional group env var name (e.g. `ODEDIFFEQ_TEST_GROUP`). |
 | `group-env-value` | string | `""` | Value for `group-env-name`. |
+| `apt-packages` | string | `""` | Space-separated apt packages to install before building/testing (Linux only). |
+| `container` | string | `""` | Docker container image to run the job in (e.g. `cmhyett/julia-fenics:latest` for Python-stack packages). Empty = no container. |
 
 ```yaml
 jobs:


### PR DESCRIPTION
## What

Adds two optional inputs — `apt-packages` and `container` — to the reusable **downgrade** workflows (`downgrade.yml` and `sublibrary-downgrade.yml`), mirroring the inputs `tests.yml` already exposes on master.

Right now the downgrade legs of Python/R-stack packages cannot install their system dependencies: neither `downgrade.yml` nor `sublibrary-downgrade.yml` expose `apt-packages` or `container`, so a caller has no way to provision e.g. scipy or an R install on the downgrade job the way it already can on its `tests.yml` job. This closes that gap.

## Changes (mirroring `tests.yml`)

For each workflow:
- New `apt-packages` input (string, default `""`): "Space-separated apt packages to install before building/testing (Linux only)."
- New `container` input (string, default `""`): "Docker container image to run the job in, e.g. for Python-stack packages (empty string = no container)".
- `container: ${{ inputs.container }}` on the job that runs build/test (the `downgrade` job in `downgrade.yml`; the matrix `test` job in `sublibrary-downgrade.yml`).
- An `Install system packages` step, gated on `if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"`, placed **before** `julia-actions/julia-buildpkg` (after the `julia-downgrade-compat` step), matching the exact step text/placement in `tests.yml`.
- README: documented both new inputs in the `downgrade.yml` and `sublibrary-downgrade.yml` input tables, mirroring the `tests.yml` wording.

The empty-string default for `container` is the same no-container pattern `tests.yml` already uses on master, so it is accepted.

`actionlint` is clean on both edited workflow files.

## Follow-up callers

Once this merges and `v1` is retagged, these downgrade legs can be wired up caller-side:
- **SciPyDiffEq.jl** — `apt-packages` / `container` to provide scipy on its downgrade job.
- **deSolveDiffEq.jl** — provision the R stack on its downgrade job.

## Scope

Only the two workflow files plus the README rows; no other changes.

NOTE: v1 must be retagged after merge for @v1 callers to pick this up. Ignore until reviewed by @ChrisRackauckas.
