### PR TITLE
feat: allow forwarding `cache` in `sublibrary-project-tests`

### DIFF
--- a/.github/workflows/sublibrary-project-tests.yml
+++ b/.github/workflows/sublibrary-project-tests.yml
@@ -61,6 +61,11 @@ on:
         default: "v1"
         required: false
         type: string
+      cache:
+        description: "Use the julia-actions/cache action for caching"
+        default: true
+        required: false
+        type: boolean
 
 jobs:
   detect:
@@ -126,4 +131,5 @@ jobs:
       allow-reresolve: ${{ inputs.allow-reresolve }}
       coverage: ${{ inputs.coverage }}
       coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
+      cache: ${{ inputs.cache }}
     secrets: "inherit"


### PR DESCRIPTION
MTK really wants to disable this