### PR TITLE
tests/sublibrary-ci: show Julia version in test job names

### DIFF
--- a/.github/workflows/sublibrary-project-tests.yml
+++ b/.github/workflows/sublibrary-project-tests.yml
@@ -112,7 +112,7 @@ jobs:
       fail-fast: false
       matrix:
         include: ${{ fromJson(needs.detect.outputs.matrix) }}
-    name: "${{ matrix.project }}${{ matrix.group != 'Core' && format(' [{0}]', matrix.group) || '' }} (julia ${{ matrix.version }})"
+    name: "${{ matrix.project }}${{ matrix.group != 'Core' && format(' [{0}]', matrix.group) || '' }} / Julia ${{ matrix.version }}"
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:
       project: "${{ matrix.project }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ on:
 
 jobs:
   tests:
-    name: "Tests${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
+    name: "Tests${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }} (Julia ${{ inputs.julia-version }})"
     continue-on-error: ${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}
     runs-on: ${{ inputs.runner != '' && fromJson(inputs.runner) || (inputs.self-hosted && 'self-hosted' || inputs.os) }}
     container: ${{ inputs.container }}


### PR DESCRIPTION
## What

In the reusable sublibrary CI workflow (`.github/workflows/sublibrary-project-tests.yml`, the `lib/*` project-model sublibrary tests), reformat the `test` job's `name:` so the per-job display name surfaces the Julia version in a clearer, distinguishing form.

The job name already interpolated the version as a parenthesized lowercase suffix (`(julia ${{ matrix.version }})`). This changes it to a `/ Julia <version>` form so the GitHub checks list reads e.g. `lib/OrdinaryDiffEqTsit5 / Julia 1.10` vs `lib/OrdinaryDiffEqTsit5 / Julia 1`, instead of distinct-version jobs being hard to tell apart.

### Before / After (the only line changed)

Before:
```yaml
name: "${{ matrix.project }}${{ matrix.group != 'Core' && format(' [{0}]', matrix.group) || '' }} (julia ${{ matrix.version }})"
```

After:
```yaml
name: "${{ matrix.project }}${{ matrix.group != 'Core' && format(' [{0}]', matrix.group) || '' }} / Julia ${{ matrix.version }}"
```

## Details

- Matrix variable carrying the Julia version is **`version`**, confirmed against both the workflow (`matrix.version` is also fed to `julia-version:`) and the matrix producer `scripts/compute_affected_sublibraries.jl` (`--projects-matrix` emits `{"project":...,"group":...,"version":...,...}`).
- The existing project and group axes in the name are preserved; only the version suffix format changed.
- **Purely cosmetic**: only the `name:` string changed — no functional/behavioral change.
- `actionlint` clean on the edited file.

## Not touched

- `sublibrary-downgrade.yml`: its `test` job has no `name:` and its matrix only has a `project` axis — the Julia version is a single `inputs.julia-version` per run, not a per-job matrix distinguisher, so it is not the same multi-version-matrix situation. Left as-is.
- Non-sublibrary `tests.yml` / `grouped-tests.yml`: out of scope.

NOTE: `v1` must be retagged after merge for `@v1` callers to pick this up.

Ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Real fix added (tests.yml leaf job name)

For reusable-workflow calls, GitHub displays the **called** workflow's job name in the checks list, overriding the caller's richer name. So the visible "Tests - <Group>" entries come from the leaf reusable `SciML/.github/.github/workflows/tests.yml@v1` `tests` job name — not from the callers (`grouped-tests.yml` / `sublibrary-project-tests.yml`). Adding the version only to the callers has no visible effect.

This PR now also edits `.github/workflows/tests.yml` to append the Julia version to that leaf job name:

Before:
```yaml
name: "Tests${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
```

After:
```yaml
name: "Tests${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }} (Julia ${{ inputs.julia-version }})"
```

`inputs.julia-version` is a real `on.workflow_call.inputs` input of `tests.yml` (default `"1"`, type string). The checks list will now read e.g. `Tests - Extended (Julia 1.10)` / `(Julia 1)` / `(Julia pre)` distinctly. `actionlint` clean.

The `sublibrary-project-tests.yml` caller-name change in this PR is cosmetic (it is the caller job name, not what GitHub shows for reusable calls); kept as-is.