### PR TITLE
codecov: fix ~/.gitconfig lock race on self-hosted runners (disable_safe_directory)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -113,7 +113,10 @@ jobs:
       - name: "Report Coverage with Codecov"
         uses: codecov/codecov-action@v7
         if: "${{ inputs.coverage && steps.coverage-dirs.outputs.directories != '' }}"
+        continue-on-error: true
         with:
           files: lcov.info
           flags: "docs"
           token: "${{ secrets.CODECOV_TOKEN }}"
+          disable_safe_directory: true
+          fail_ci_if_error: false

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -114,6 +114,9 @@ jobs:
       - name: "Report Coverage with Codecov"
         if: "${{ inputs.coverage }}"
         uses: codecov/codecov-action@v7
+        continue-on-error: true
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"
+          disable_safe_directory: true
+          fail_ci_if_error: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -226,6 +226,9 @@ jobs:
       - name: "Report Coverage with Codecov"
         uses: codecov/codecov-action@v7
         if: "${{ inputs.coverage && steps.coverage-dirs.outputs.directories != '' }}"
+        continue-on-error: true
         with:
           files: lcov.info
           token: "${{ secrets.CODECOV_TOKEN }}"
+          disable_safe_directory: true
+          fail_ci_if_error: false


### PR DESCRIPTION
## Problem (root cause, verified)

`codecov/codecov-action@v7`'s internal *Set safe directory* step runs `git config --global --add safe.directory ...`, which takes a lock on `~/.gitconfig`. The SciML self-hosted `demeter` runners share a single home directory (`/home/chrisrackauckas`) across many concurrent jobs, so those `git config --global` calls race for the same lockfile:

```
error: could not lock config file /home/chrisrackauckas/.gitconfig: File exists
```

The action then exits 255 and fails the job **after the tests already passed**. `fail_ci_if_error: false` does not help here because the failure happens in a pre-upload *setup* step, not in the upload itself. 100% of observed codecov job failures were on `demeter`; 0% on GitHub-hosted/ephemeral runners.

## Fix

On every `codecov/codecov-action@v7` step in the repo:

- `disable_safe_directory: true` — skips the racing `git config --global` call entirely. This is a real input of codecov-action (added in v5+; present in v7). Harmless on hosted runners since the checkout dir is already trusted there.
- `continue-on-error: true` on the step — so any future codecov setup-step non-zero exit can never fail an otherwise-green job.
- `fail_ci_if_error: false` set explicitly in `with:` for clarity/defense-in-depth.

### Files touched
- `.github/workflows/tests.yml` (codecov step)
- `.github/workflows/documentation.yml` (codecov step)
- `.github/workflows/downstream.yml` (codecov step)

actionlint clean.

NOTE: v1 must be retagged after merge for @v1 callers. Ignore until reviewed by @ChrisRackauckas.