### PR TITLE
cache: default false in all reusable workflows (supersedes #90)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -38,7 +38,7 @@ on:
         type: string
       cache:
         description: "Use the julia-actions/cache action for caching"
-        default: true
+        default: false
         required: false
         type: boolean
       coverage:

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -38,7 +38,7 @@ on:
         type: string
       cache:
         description: "Use the julia-actions/cache action for caching"
-        default: true
+        default: false
         required: false
         type: boolean
       buildpkg:

--- a/.github/workflows/grouped-tests.yml
+++ b/.github/workflows/grouped-tests.yml
@@ -71,7 +71,7 @@ on:
         type: string
       cache:
         description: "Use the julia-actions/cache action for caching"
-        default: true
+        default: false
         required: false
         type: boolean
 

--- a/.github/workflows/grouped-tests.yml
+++ b/.github/workflows/grouped-tests.yml
@@ -69,6 +69,11 @@ on:
         default: "v1"
         required: false
         type: string
+      cache:
+        description: "Use the julia-actions/cache action for caching"
+        default: true
+        required: false
+        type: boolean
 
 jobs:
   detect:
@@ -116,4 +121,5 @@ jobs:
       coverage-directories: "${{ inputs.coverage-directories }}"
       apt-packages: "${{ inputs.apt-packages }}"
       container: "${{ inputs.container }}"
+      cache: ${{ inputs.cache }}
     secrets: "inherit"

--- a/.github/workflows/sublibrary-project-tests.yml
+++ b/.github/workflows/sublibrary-project-tests.yml
@@ -61,6 +61,11 @@ on:
         default: "v1"
         required: false
         type: string
+      cache:
+        description: "Use the julia-actions/cache action for caching"
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   detect:
@@ -126,4 +131,5 @@ jobs:
       allow-reresolve: ${{ inputs.allow-reresolve }}
       coverage: ${{ inputs.coverage }}
       coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
+      cache: ${{ inputs.cache }}
     secrets: "inherit"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,11 @@ jobs:
           arch: "${{ inputs.julia-arch || runner.arch }}"
 
       - uses: julia-actions/cache@v3
-        if: "${{ inputs.cache }}"
+        # Skip caching on self-hosted runners: demeter has a persistent, already
+        # warm depot (20-29GB), so the cache always MISSES and the post-job save
+        # tar-uploads 20-29GB at ~7MB/s (+30-62 min/job). Only useful on
+        # GitHub-hosted/ephemeral runners (empty `runner` and not `self-hosted`).
+        if: "${{ inputs.cache && inputs.runner == '' && !inputs.self-hosted }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ on:
         type: string
       cache:
         description: "Use the julia-actions/cache action for caching"
-        default: true
+        default: false
         required: false
         type: boolean
       buildpkg:


### PR DESCRIPTION
## cache: default `false` in all reusable workflows

Chris's call: caching does nothing useful on GitHub-hosted runners and is actively harmful on the self-hosted demeter runner, so the `cache` input now defaults to `false` everywhere it exists, fleet-wide.

### Why caching is not worth defaulting on

`julia-actions/cache` restores a coarse, **OS-only-keyed depot (~355 MB)** that rarely matches the actual `Manifest.toml`. Because the key doesn't track the manifest, the restored depot is almost always stale, so Julia **re-runs precompilation anyway** — the cache buys little to nothing on the compile side, while still adding the restore/save steps that can **race or fail** (concurrent jobs, partial tars).

- **GitHub-hosted / ephemeral runners:** net-neutral. The depot starts empty, the coarse cache rarely hits the manifest, precompile re-runs, and the save/restore overhead roughly cancels any savings.
- **Self-hosted demeter:** catastrophic. demeter already has a **persistent, always-warm depot (20-29 GB)**, so the cache action's restore always MISSES and the post-job save tar-uploads the whole 20-29 GB depot at ~7 MB/s — **+30-60 min per job**, for zero benefit.

So there is no runner type where defaulting caching on is a win. Default it `false`.

### What changed

`cache` input `default: true` → `default: false` (and added where missing), across every reusable that can cache:

- `tests.yml` — default flipped to `false`. The existing self-hosted gate on the cache step is **kept** as defense in depth: `if: "${{ inputs.cache && inputs.runner == '' && !inputs.self-hosted }}"`, so even an explicit `cache: true` can never trigger the demeter footgun.
- `grouped-tests.yml` — default flipped to `false` (forwards `cache: ${{ inputs.cache }}` to `tests.yml`).
- `sublibrary-project-tests.yml` — **added** a `cache` boolean input (default `false`) and forward it into the `tests.yml@v1` call. This is the toggle PR #90 added, but defaulting `false` instead of `true`.
- `documentation.yml` — default flipped to `false`.
- `downstream.yml` — default flipped to `false`.

The input is **kept everywhere** so any individual repo can still opt back in with `cache: true` if it ever proves worthwhile for that repo (and even then the self-hosted gate protects demeter).

`actionlint` clean on all five edited files.

### Supersedes #90

This **supersedes PR #90**, which added the sublibrary cache toggle but defaulted it to `true`. This PR adds the same toggle defaulting `false` (the correct default per the analysis above) and applies the same default-false treatment fleet-wide. **Recommend closing #90.**

---

v1 must be retagged after merge. Ignore until reviewed by @ChrisRackauckas.
