### PR TITLE
tests.yml: set group env via `shell: bash` so GROUP propagates on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -213,7 +213,14 @@ jobs:
         # read e.g. ODEDIFFEQ_TEST_GROUP work the same as the default GROUP. The
         # name must be dynamic, which the env: map can't express, so write it to
         # $GITHUB_ENV here.
+        #
+        # shell: bash is required: the default shell on windows runners is
+        # PowerShell, which does not expand the bash-style "$GITHUB_ENV" (it would
+        # write to a file literally named $GITHUB_ENV instead), so the group env
+        # var would silently never be set and the package's runtests.jl would fall
+        # back to its default group (e.g. "All") on Windows only.
         if: "${{ steps.prerelease-gate.outputs.run != 'false' }}"
+        shell: bash
         run: echo "${{ inputs.group-env-name }}=${{ inputs.group }}" >> "$GITHUB_ENV"
 
       - name: "Run tests ${{ inputs.self-hosted && '' || format('on {0}', inputs.os) }} with Julia v${{ inputs.julia-version }}"


### PR DESCRIPTION
## Problem

The `Set test group env` step in `tests.yml` writes `<group-env-name>=<group>` to `$GITHUB_ENV` using bash `$VAR` syntax but declares no `shell:`. On windows runners the default shell is **PowerShell**, which does not expand `"$GITHUB_ENV"` the bash way — it writes to a file literally named `$GITHUB_ENV` rather than appending to the runner environment file. Result: the group env var (e.g. `GROUP`) is **silently never set on Windows**.

With `GROUP` unset, a package's `runtests.jl` falls back to its default group (SciMLTesting's `run_tests()` defaults to `"All"`). So a matrix entry scheduled as **Core** on windows-latest actually ran **every** group folder, including groups that carry their own `test/<Group>/Project.toml` (e.g. an AD group depending on SciMLSensitivity) — inside the main test environment. Activating that second project mid-session upgrades already-loaded packages and triggers precompile conflicts.

### Observed in SciML/DiffEqCallbacks.jl
`tests / Core (julia 1|lts, windows-latest)` failed with:
```
invalid method definition in OrdinaryDiffEqCorePolyesterExt: exported function OrdinaryDiffEqCore._polyester_batch does not exist
```
because the Core job leaked into the `AD` group (`Activating project at ...\test\AD`, `OrdinaryDiffEqCore v4.3.0 [loaded: v3.33.1]`) and `using SciMLSensitivity` failed to precompile against the stale loaded `OrdinaryDiffEqCore`. Linux/macOS Core jobs (bash default) ran only the Core folder and passed.

## Fix

Add `shell: bash` to the `Set test group env` step so `$GITHUB_ENV` expands on every OS and the group is set correctly on Windows. This is the same shell the adjacent GITHUB_ENV/GITHUB_OUTPUT steps already use.

`downgrade.yml` is unaffected: it sets `GROUP` via the runtest step's `env:` map (shell-independent).

This fixes Windows grouped-tests for every SciML repo that uses `grouped-tests.yml`/`tests.yml`, not just DiffEqCallbacks.jl. `v1` will need to be retagged to this commit for callers pinned at `@v1` to pick it up.

Please ignore until reviewed by @ChrisRackauckas