### PR TITLE
tests.yml: develop in-repo [sources] for monorepo ROOT (project: '.') on the LTS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,7 +145,7 @@ jobs:
           token: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: "Checkout SciML/.github for the develop-sources helper"
-        if: "${{ inputs.buildpkg && inputs.project != '@.' && inputs.project != '.' }}"
+        if: "${{ inputs.buildpkg && inputs.project != '@.' }}"
         uses: actions/checkout@v7
         with:
           repository: SciML/.github
@@ -154,12 +154,18 @@ jobs:
 
       - name: "Develop in-repo [sources] path deps of ${{ inputs.project }}"
         # On Julia < 1.11 the [sources] section is not auto-resolved during
-        # build/test, so develop the in-repo path deps the sub-project (e.g. a
-        # lib/* sublibrary) declares -- transitively, but skipping a developed
-        # dependency's *test-only* [sources] so they don't become phantom direct
-        # deps (SciML/Optimization.jl#1228). No-op on >= 1.11. See
-        # scripts/develop_sources.jl for the full rationale.
-        if: "${{ inputs.buildpkg && inputs.project != '@.' && inputs.project != '.' }}"
+        # build/test, so develop the in-repo path deps the sub-project declares
+        # -- transitively, but skipping a developed dependency's *test-only*
+        # [sources] so they don't become phantom direct deps
+        # (SciML/Optimization.jl#1228). No-op on >= 1.11. This covers both a
+        # lib/* sublibrary (project: lib/<name>) AND a monorepo *root* project
+        # (project: '.') whose [sources] pin in-repo siblings (e.g.
+        # OptimalUncertaintyQuantification's root deps on its lib/* packages):
+        # without developing them, `julia-buildpkg` on the LTS fails with
+        # "expected package <Sibling> ... to be registered". Only the default
+        # environment sentinel '@.' (an ordinary single package with no in-repo
+        # [sources]) is exempt. See scripts/develop_sources.jl for the rationale.
+        if: "${{ inputs.buildpkg && inputs.project != '@.' }}"
         shell: julia --color=yes {0}
         run: |
           # `shell: julia {0}` writes this body to a temp file under RUNNER_TEMP and


### PR DESCRIPTION
## Problem

`tests.yml`'s "Develop in-repo [sources] path deps" step (and the helper checkout before it) is gated with:

```yaml
if: "${{ inputs.buildpkg && inputs.project != '@.' && inputs.project != '.' }}"
```

So it runs for `lib/*` sublibraries (`project: lib/<name>`) but is **skipped for a monorepo ROOT** project passed as `project: '.'` — which is exactly what `grouped-tests.yml` passes for monorepo roots.

On Julia < 1.11 the `[sources]` table is **not** auto-resolved during build/test. A root project whose `[deps]` are pinned to in-repo siblings via `[sources]` therefore can't be built on the LTS. Concretely, on `SciML/OptimalUncertaintyQuantification.jl` (root `[deps]` = CanonicalMoments / DiscreteMeasures / OUQBase, each `{ path = "lib/<name>" }` in root `[sources]`), `julia-buildpkg` on `julia lts` fails before any test runs:

```
ERROR: LoadError: expected package `CanonicalMoments [58d2c334]` to be registered
```

red-flagging `tests / Core (julia lts)` and `tests / QA (julia lts)`.

## Fix

Relax both gates to only exempt the default-environment sentinel `'@.'` (an ordinary single package, which by definition has no in-repo `[sources]`). `'.'` now develops its in-repo `[sources]` siblings just like a `lib/*` sublibrary.

`develop_sources` already handles the root correctly:
- `collect_source_paths` exempts the **root** project from the test-only-sources filter, so the root's own runtime `[sources]` are developed;
- it is a safe no-op when `'.'` declares no `[sources]`, and on Julia >= 1.11 entirely.

No behavior change for `@.` callers (still skipped) or `lib/*` callers (still develop).

## Local verification (Julia 1.10.11, against OptimalUncertaintyQuantification.jl)

- Bare `Pkg.instantiate()` on the repo root **reproduces** `expected package CanonicalMoments ... to be registered`.
- `develop_sources(".")` + `Pkg.instantiate()` **resolves and precompiles the full stack** (ModelingToolkit / Optimization / OUQBase + the three `lib/*` sources) cleanly — `INSTANTIATE OK`.

## Rollout

After merge, re-tag `v1` to the new master so `@v1` callers (incl. OptimalUncertaintyQuantification.jl) pick up the fix.

## Out of scope (separate root cause)

The `Downgrade` / `Downgrade Sublibraries` reds on the same monorepo are a **`julia-actions/julia-downgrade-compat`** bug (its `create_merged_project` leaves path-`[sources]` deps in the merged base `[deps]`, so the resolver hits `unknown package UUID`), not a SciML/.github issue — reported separately.

Please ignore until reviewed by @ChrisRackauckas.