### PR TITLE
documentation.yml: set permissions (contents: write) in the reusable (fix docs-deploy at the source)

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,6 +56,15 @@ on:
         required: false
         type: boolean
 
+# `deploydocs` pushes to gh-pages via GITHUB_TOKEN (when no DOCUMENTER_KEY), which
+# needs `contents: write`. Set it here in the reusable so consumer caller jobs don't
+# each have to grant it (the prior per-repo permissions blocks dropped in the CI
+# centralization migration were the symptom; this is the fix at the source).
+permissions:
+  actions: write
+  contents: write
+  statuses: write
+
 jobs:
   tests:
     name: "Build and Deploy Documentation"


### PR DESCRIPTION
Per @ChrisRackauckas: fix the docs-deploy gh-pages 403 **centrally** instead of per-repo.

The reusable `documentation.yml` deploys via `GITHUB_TOKEN` (when no `DOCUMENTER_KEY`), which needs `contents: write`. It declared **no `permissions:`**, so each consumer's caller job had to grant write — and the CI-centralization migration dropped those per-repo blocks, 403'ing gh-pages across many repos (CatalystNetworkAnalysis, ColPrac, Evolutionary, PDEBase, SparseColumnPivotedQR, OrdinaryDiffEqOperatorSplitting, …).

This adds a workflow-level `permissions: {contents: write, actions: write, statuses: write}` to the reusable, so **all consumers get it without per-repo blocks**. Mirrors the grant that the per-caller fix (OrdinaryDiffEqOperatorSplitting #90, verified → Documentation green) used — just moved to the source.

**Needs a `v1` retag** to take effect. Once retagged, the ~6 per-repo `permissions`-block PRs I opened can be closed as superseded.

⚠️ Caveat: GitHub gates a reusable's token by the caller — this works as long as the consumer caller doesn't *restrict* permissions (SciML callers don't) and the org token max allows write (it does — #90's explicit grant succeeded). If any repo's org/caller hard-caps to read-only, that repo would still need its own block or the org Workflow-permissions setting.

Please ignore until reviewed by @ChrisRackauckas.