### PR TITLE
downgrade.yml: default no_promote=Mooncake (skip its unresolvable floor-check)

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -33,6 +33,11 @@ on:
         default: "deps"
         required: false
         type: string
+      no_promote:
+        description: "Comma-separated weakdep extensions kept as weakdeps (not floor-checked) during merged downgrade resolution. Defaults to Mooncake, whose dependency graph Resolver.jl cannot --min-resolve (StefanKarpinski/Resolver.jl#24), so its floor-check is skipped fleet-wide while every other weakdep extension is still floor-checked. Passed to julia-actions/julia-downgrade-compat."
+        default: "Mooncake"
+        required: false
+        type: string
       self-hosted:
         description: "Run the job on a self hosted machine"
         default: false
@@ -122,6 +127,7 @@ jobs:
           skip: "${{ env.EFFECTIVE_SKIP }}"
           projects: "${{ inputs.projects }}"
           mode: "${{ inputs.mode != '' && inputs.mode || 'deps' }}"
+          no_promote: "${{ inputs.no_promote }}"
 
       - name: "Install system packages"
         if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"


### PR DESCRIPTION
## What

Adds a `no_promote` input to the reusable `downgrade.yml`, passed through to `julia-actions/julia-downgrade-compat`, **defaulting to `Mooncake`**.

`no_promote` keeps the named weakdep extensions as weakdeps during merged downgrade resolution instead of promoting them into the joint floor-resolve (they install at latest, are never force-min-resolved). Mooncake is the fleet-wide culprit: its dependency graph cannot be `--min`-resolved by `Resolver.jl` (**StefanKarpinski/Resolver.jl#24** — Pkg resolves the identical graph fine), and the merged resolve is registry-fragile. Skipping just Mooncake's promotion greens the Downgrade lane fleet-wide while **every other weakdep extension is still promoted and floor-tested together** — the most conservative fix.

Callers can override: add more backends (e.g. `Reactant`), or set `no_promote: ""` to floor-check Mooncake in a repo where its graph happens to resolve.

## Ready — dependency satisfied

`julia-actions/julia-downgrade-compat#52` (which adds the `no_promote` action input) **is merged and released as v2.6.0**, and the moving `v2` tag now points to it (`3cae9054`), so `julia-downgrade-compat@v2` used here already understands `no_promote`. Merging this activates the fleet default immediately.

Ready for review by @ChrisRackauckas.