### PR TITLE
Shard sublibrary-project-tests matrix under GitHub's 256-job cap

### DIFF
--- a/.github/workflows/sublibrary-project-tests.yml
+++ b/.github/workflows/sublibrary-project-tests.yml
@@ -71,7 +71,19 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.compute.outputs.matrix }}
+      # The affected-sublibrary matrix, split into fixed-size shards so no single
+      # test job's strategy.matrix exceeds GitHub's hard 256-jobs-per-matrix cap.
+      # Above that cap GitHub refuses to instantiate ANY cell and fails the run
+      # with no jobs created (a monorepo-wide QA/EI conversion can touch enough
+      # sublibraries to blow past it). Each shard_N feeds a separate test-N job.
+      shard_1: ${{ steps.compute.outputs.shard_1 }}
+      shard_2: ${{ steps.compute.outputs.shard_2 }}
+      shard_3: ${{ steps.compute.outputs.shard_3 }}
+      shard_4: ${{ steps.compute.outputs.shard_4 }}
+      has_1: ${{ steps.compute.outputs.has_1 }}
+      has_2: ${{ steps.compute.outputs.has_2 }}
+      has_3: ${{ steps.compute.outputs.has_3 }}
+      has_4: ${{ steps.compute.outputs.has_4 }}
       has_changes: ${{ steps.compute.outputs.has_changes }}
     steps:
       - uses: actions/checkout@v7
@@ -103,20 +115,111 @@ jobs:
           echo "$CHANGED" | grep "^lib/" || echo "(none)"
           MATRIX=$(echo "$CHANGED" | julia .sciml-dotgithub/scripts/compute_affected_sublibraries.jl . --projects-matrix)
           echo "Matrix: $MATRIX"
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          if [ "$MATRIX" = "[]" ]; then
+          # Shard the include list into <=SHARD_SIZE-cell batches. Four shards of
+          # 200 cover 800 cells (far past any realistic affected-set) while every
+          # per-job matrix stays under GitHub's 256 cap.
+          SHARD_SIZE=200
+          TOTAL=$(echo "$MATRIX" | jq 'length')
+          echo "Total matrix cells: $TOTAL"
+          if [ "$TOTAL" -gt 800 ]; then
+            echo "::error::Affected-sublibrary matrix has $TOTAL cells (> 800 shard capacity). Add another shard_N/test-N pair in sublibrary-project-tests.yml."
+            exit 1
+          fi
+          if [ "$TOTAL" = "0" ]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
+          for i in 1 2 3 4; do
+            START=$(( (i - 1) * SHARD_SIZE ))
+            SHARD=$(echo "$MATRIX" | jq -c ".[${START}:$(( START + SHARD_SIZE ))]")
+            echo "shard_${i}=${SHARD}" >> "$GITHUB_OUTPUT"
+            if [ "$(echo "$SHARD" | jq 'length')" = "0" ]; then
+              echo "has_${i}=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "has_${i}=true" >> "$GITHUB_OUTPUT"
+            fi
+          done
 
-  test:
+  test-1:
     needs: detect
-    if: needs.detect.outputs.has_changes == 'true'
+    if: needs.detect.outputs.has_1 == 'true'
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.detect.outputs.matrix) }}
+        include: ${{ fromJson(needs.detect.outputs.shard_1) }}
+    name: "${{ matrix.project }}${{ matrix.group != 'Core' && format(' [{0}]', matrix.group) || '' }} / Julia ${{ matrix.version }}"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      project: "${{ matrix.project }}"
+      group: "${{ matrix.group }}"
+      group-env-name: "${{ inputs.group-env-name }}"
+      julia-version: "${{ matrix.version }}"
+      runner: ${{ toJson(matrix.runner) }}
+      timeout-minutes: ${{ matrix.timeout }}
+      num-threads: "${{ matrix.num_threads }}"
+      check-bounds: "${{ inputs.check-bounds }}"
+      allow-reresolve: ${{ inputs.allow-reresolve }}
+      coverage: ${{ inputs.coverage }}
+      coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
+      cache: ${{ inputs.cache }}
+    secrets: "inherit"
+
+  test-2:
+    needs: detect
+    if: needs.detect.outputs.has_2 == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.detect.outputs.shard_2) }}
+    name: "${{ matrix.project }}${{ matrix.group != 'Core' && format(' [{0}]', matrix.group) || '' }} / Julia ${{ matrix.version }}"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      project: "${{ matrix.project }}"
+      group: "${{ matrix.group }}"
+      group-env-name: "${{ inputs.group-env-name }}"
+      julia-version: "${{ matrix.version }}"
+      runner: ${{ toJson(matrix.runner) }}
+      timeout-minutes: ${{ matrix.timeout }}
+      num-threads: "${{ matrix.num_threads }}"
+      check-bounds: "${{ inputs.check-bounds }}"
+      allow-reresolve: ${{ inputs.allow-reresolve }}
+      coverage: ${{ inputs.coverage }}
+      coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
+      cache: ${{ inputs.cache }}
+    secrets: "inherit"
+
+  test-3:
+    needs: detect
+    if: needs.detect.outputs.has_3 == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.detect.outputs.shard_3) }}
+    name: "${{ matrix.project }}${{ matrix.group != 'Core' && format(' [{0}]', matrix.group) || '' }} / Julia ${{ matrix.version }}"
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      project: "${{ matrix.project }}"
+      group: "${{ matrix.group }}"
+      group-env-name: "${{ inputs.group-env-name }}"
+      julia-version: "${{ matrix.version }}"
+      runner: ${{ toJson(matrix.runner) }}
+      timeout-minutes: ${{ matrix.timeout }}
+      num-threads: "${{ matrix.num_threads }}"
+      check-bounds: "${{ inputs.check-bounds }}"
+      allow-reresolve: ${{ inputs.allow-reresolve }}
+      coverage: ${{ inputs.coverage }}
+      coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
+      cache: ${{ inputs.cache }}
+    secrets: "inherit"
+
+  test-4:
+    needs: detect
+    if: needs.detect.outputs.has_4 == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.detect.outputs.shard_4) }}
     name: "${{ matrix.project }}${{ matrix.group != 'Core' && format(' [{0}]', matrix.group) || '' }} / Julia ${{ matrix.version }}"
     uses: "SciML/.github/.github/workflows/tests.yml@v1"
     with:

--- a/README.md
+++ b/README.md
@@ -634,7 +634,11 @@ The script's output modes:
 
 Lists the affected `lib/*` (with change detection) and runs each via
 `tests.yml` `project: lib/X`, expanding `test_groups.toml`. No root dispatcher
-needed.
+needed. The affected-sublibrary matrix is sharded into 200-cell batches across
+parallel `test-N` jobs so no single `strategy.matrix` exceeds GitHub's hard
+256-jobs-per-matrix cap (above it GitHub instantiates no cells and fails the run
+with nothing scheduled — reached by monorepo-wide changes that touch many
+sublibraries at once, e.g. a QA/ExplicitImports conversion).
 
 | Input | Type | Default | Description |
 |---|---|---|---|


### PR DESCRIPTION
## Problem

`sublibrary-project-tests.yml` feeds the entire affected-sublibrary matrix into a **single** `strategy.matrix` on a job that calls a reusable workflow (`uses: tests.yml@v1`). GitHub caps a matrix at **256 jobs**; above that it instantiates **no cells** and fails the run with nothing scheduled (no annotation, only `detect` shows up as a job).

A monorepo-wide change that touches many sublibraries at once trips this. Concretely, [OrdinaryDiffEq.jl #3777](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3777) (a QA/ExplicitImports conversion editing ~54 `lib/*/test/qa/*`) made `detect` compute a **266-cell** projects-matrix (incl. **56 QA cells**). `detect` succeeded and `has_changes=true`, but the `test` job produced **zero** jobs and the run failed — so **QA never ran for any sublibrary**, silently. Smaller PRs (e.g. an 87-cell master push) spawn fine, including their QA cells, which is why this went unnoticed.

## Fix

Split the computed projects-matrix into **200-cell shards** in `detect` and run **one `test-N` reusable-workflow job per shard** (4 shards → 800-cell capacity), each gated by `has_N`. Every per-job `strategy.matrix` now stays well under 256.

- Small affected sets are unchanged: everything lands in `shard_1`; shards 2–4 skip via `has_N == 'false'`.
- A `>800`-cell total **errors loudly** asking for another shard, rather than silently dropping jobs.

## Validation (local)

Replayed the exact detect shell logic against the real 266-cell #3777 matrix (extracted from the failing run's detect log):

```
shard_1: len=200 (44 QA)  shard_2: len=66 (12 QA)  shard_3/4: len=0
union == original (order-preserving) = true; 56 QA cells preserved
```

Also verified the 4-cell (single-sublib) and empty-matrix cases behave as before. YAML parses. No external consumer references this workflow's removed `matrix`/`has_changes` outputs (`grouped-tests.yml` has its own separate `detect`).

Takes effect for OrdinaryDiffEq #3777 (and every monorepo using `@v1`) once merged and `v1` is retagged.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)