### PR TITLE
Export downstream test group input

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -92,6 +92,8 @@ jobs:
 
       - name: "Run tests ${{ inputs.self-hosted && '' || format('on {0}', inputs.os) }} with Julia v${{ inputs.julia-version }}"
         shell: julia --color=yes --project=downstream {0}
+        env:
+          GROUP: ${{ inputs.group }}
         run: |
           using Pkg
           try


### PR DESCRIPTION
This PR should be ignored until reviewed by @ChrisRackauckas.

## Summary
- Exports the reusable downstream workflow `group` input as `GROUP` for the Julia test step.
- This lets downstream packages that dispatch on `ENV["GROUP"]` actually run the requested group instead of their default/full suite.

## Context
`SciML/.github/.github/workflows/downstream.yml@v1` accepts a `group` input and uses it in the job name, but the Julia test step does not currently set `GROUP`. In NonlinearSolve downstream CI this made the ModelingToolkit jobs labelled `InterfaceI`, `InterfaceII`, and `Initialization` continue beyond the requested group and run additional groups in the same process.

## Local verification
- `git diff --check`
  - Result: passed
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/downstream.yml"); puts "downstream.yml parsed"'`
  - Result: `downstream.yml parsed`

## Note
Callers pinned to `SciML/.github/.github/workflows/downstream.yml@v1` will need the `v1` tag/reference updated after this lands to consume the fix.
