### PR TITLE
tests.yml: install i386 runtime libs before setup-julia for 32-bit legs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -129,6 +129,18 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: "Install 32-bit runtime libraries (i386)"
+        # A 32-bit (i686) Julia cannot exec on the 64-bit Linux runners without
+        # the i386 dynamic loader and C/C++ runtime. setup-julia invokes julia
+        # during its own step, so these must be installed BEFORE it — otherwise
+        # the run fails with `spawn .../x86/bin/julia ENOENT` (missing loader).
+        if: "${{ (inputs.julia-arch == 'x86' || inputs.julia-arch == 'i686') && runner.os == 'Linux' }}"
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libc6:i386 libstdc++6:i386 libgcc-s1:i386 libatomic1:i386
+
       - name: "Setup Julia ${{ inputs.julia-version }}"
         uses: julia-actions/setup-julia@v3
         with:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -475,6 +475,22 @@ end
     end
 end
 
+# A 32-bit (x86/i686) Julia leg needs the i386 loader + C/C++ runtime installed
+# BEFORE setup-julia runs julia, or the run dies with `spawn .../x86/bin/julia
+# ENOENT`. Assert tests.yml has that install step, gates it on a 32-bit arch on
+# Linux, and orders it ahead of the Setup Julia step.
+@testset "tests.yml installs i386 runtime libs before setup-julia for 32-bit legs" begin
+    txt = read(joinpath(@__DIR__, "..", ".github", "workflows", "tests.yml"), String)
+    @test occursin("libc6:i386", txt)
+    @test occursin("dpkg --add-architecture i386", txt)
+    @test occursin("inputs.julia-arch == 'x86'", txt)
+    @test occursin("runner.os == 'Linux'", txt)
+    # Order: the i386 install must come before the setup-julia invocation.
+    i386_at = findfirst("libc6:i386", txt)
+    setup_at = findfirst("julia-actions/setup-julia", txt)
+    @test i386_at !== nothing && setup_at !== nothing && first(i386_at) < first(setup_at)
+end
+
 # develop_sources.jl: the [sources] develop helper used by tests.yml on Julia
 # <1.11. The pure path-collection (collect_source_paths) is tested here without
 # mutating any environment.


### PR DESCRIPTION
Second half of enabling 32-bit test lanes (first half — the `arch` axis + `group` alias — shipped in #113 / v1.24.0).

## Problem
A 32-bit leg (a `test_groups.toml` group with `arch = "x86"`, forwarded as `julia-arch: x86`) fails at the **Setup Julia** step on the 64-bit Linux runners:

```
spawn /home/runner/_work/_tool/julia/1.12.6/x86/bin/julia ENOENT
```

The i686 Julia binary downloads fine, but it can't `exec` without the i386 dynamic loader / C++ runtime, which `ubuntu-latest` lacks. `setup-julia` invokes julia during its own step, so an apt step later in the job is too late.

## Fix
Add a step **before** `setup-julia`, gated on a 32-bit `julia-arch` on Linux, that installs the i386 runtime:

```yaml
- name: "Install 32-bit runtime libraries (i386)"
  if: "${{ (inputs.julia-arch == 'x86' || inputs.julia-arch == 'i686') && runner.os == 'Linux' }}"
  run: |
    sudo dpkg --add-architecture i386
    sudo apt-get update
    sudo apt-get install -y --no-install-recommends \
      libc6:i386 libstdc++6:i386 libgcc-s1:i386 libatomic1:i386
```

Non-32-bit legs are untouched (the `if` is false — no extra time).

## Verification
In a clean `ubuntu:24.04` container (matching `ubuntu-latest`):
- **Before** the libs: `julia-1.12.6/bin/julia: cannot execute: required file not found` (the ENOENT).
- **After** `apt install libc6:i386 …`: `WORD_SIZE=32 ARCH=i686 VERSION=1.12.6` — runs.

Added a `runtests.jl` testset asserting the step is present, gated on 32-bit + Linux, and ordered before `setup-julia`. Full suite passes; Runic-clean.

## Companion changes
- SciMLTesting: folder discovery must skip matrix-only alias sections so `GROUP=All` / bare `Pkg.test` don't demand a `test/<name>/` folder for the 32-bit lane (separate PR).
- Consumer: SciML/FindFirstFunctions.jl re-adds its `Core 32-bit` lane once this + the SciMLTesting change are released.

Please ignore until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)