### PR TITLE
Support monorepo package projects in downstream CI

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -26,6 +26,11 @@ on:
         default: ""
         required: false
         type: string
+      upstream-subdirs:
+        description: "Comma-separated package paths in the calling repository to develop"
+        default: "."
+        required: false
+        type: string
       group:
         description: "The 'GROUP' of tests that need to be run. This will requires an ENV `GROUP` to be (conditionally) defined within your package tests as well to selectively run groups of tests"
         default: "All"
@@ -100,6 +105,7 @@ jobs:
         env:
           GROUP: ${{ inputs.group }}
           DOWNSTREAM_SUBDIR: ${{ inputs.subdir }}
+          UPSTREAM_SUBDIRS: ${{ inputs.upstream-subdirs }}
         run: |
           using Pkg
           downstream_project = normpath(joinpath("downstream", ENV["DOWNSTREAM_SUBDIR"]))
@@ -109,7 +115,15 @@ jobs:
           @info "Selected downstream project" downstream_project
           try
             # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            upstream_projects = filter(!isempty, strip.(split(ENV["UPSTREAM_SUBDIRS"], ',')))
+            isempty(upstream_projects) && error("No upstream package projects selected")
+            upstream_projects = normpath.(upstream_projects)
+            for project in upstream_projects
+              isfile(joinpath(project, "Project.toml")) ||
+                error("No upstream Project.toml at $project")
+            end
+            @info "Selected upstream projects" upstream_projects
+            Pkg.develop(map(project -> PackageSpec(path=project), upstream_projects))
             Pkg.update()
             Pkg.test(coverage=${{ inputs.coverage }})  # resolver may fail with test time deps
           catch err

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -21,6 +21,11 @@ on:
         description: "The name of the downstream repository that needs to be tested"
         required: true
         type: string
+      subdir:
+        description: "Path to the downstream package within the repository"
+        default: ""
+        required: false
+        type: string
       group:
         description: "The 'GROUP' of tests that need to be run. This will requires an ENV `GROUP` to be (conditionally) defined within your package tests as well to selectively run groups of tests"
         default: "All"
@@ -94,8 +99,14 @@ jobs:
         shell: julia --color=yes --project=downstream {0}
         env:
           GROUP: ${{ inputs.group }}
+          DOWNSTREAM_SUBDIR: ${{ inputs.subdir }}
         run: |
           using Pkg
+          downstream_project = normpath(joinpath("downstream", ENV["DOWNSTREAM_SUBDIR"]))
+          isfile(joinpath(downstream_project, "Project.toml")) ||
+            error("No downstream Project.toml at $downstream_project")
+          Pkg.activate(downstream_project)
+          @info "Selected downstream project" downstream_project
           try
             # force it to use this PR's version of the package
             Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ catching breakage you'd otherwise only find after release.
 |---|---|---|---|
 | `repo` | string | — **(required)** | Downstream repo name (e.g. `OrdinaryDiffEq.jl`). |
 | `subdir` | string | `""` | Package path inside a monorepo (e.g. `lib/DiffEqBase`). |
+| `upstream-subdirs` | string | `"."` | Comma-separated package paths in the calling repository to develop. |
 | `owner` | string | `"SciML"` | Owner of the downstream repo. |
 | `group` | string | `"All"` | Downstream test group. |
 | `julia-version` | string | `"1"` | Julia version. |
@@ -228,6 +229,20 @@ jobs:
       repo: "OrdinaryDiffEq.jl"
       subdir: "lib/DiffEqBase"
       group: "Core"
+    secrets: "inherit"
+```
+
+When the calling repository is a monorepo and the downstream package consumes
+one or more of its sublibraries, select those upstream projects explicitly:
+
+```yaml
+jobs:
+  downstream-mtk:
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      repo: "ModelingToolkit.jl"
+      upstream-subdirs: "lib/BoundaryValueDiffEqMIRK,lib/BoundaryValueDiffEqAscher"
+      group: "All"
     secrets: "inherit"
 ```
 

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ catching breakage you'd otherwise only find after release.
 | Input | Type | Default | Description |
 |---|---|---|---|
 | `repo` | string | — **(required)** | Downstream repo name (e.g. `OrdinaryDiffEq.jl`). |
+| `subdir` | string | `""` | Package path inside a monorepo (e.g. `lib/DiffEqBase`). |
 | `owner` | string | `"SciML"` | Owner of the downstream repo. |
 | `group` | string | `"All"` | Downstream test group. |
 | `julia-version` | string | `"1"` | Julia version. |
@@ -214,6 +215,19 @@ jobs:
     uses: "SciML/.github/.github/workflows/downstream.yml@v1"
     with:
       repo: "${{ matrix.repo }}"
+    secrets: "inherit"
+```
+
+For a package that lives in a monorepo, select the package project explicitly:
+
+```yaml
+jobs:
+  downstream-diffeqbase:
+    uses: "SciML/.github/.github/workflows/downstream.yml@v1"
+    with:
+      repo: "OrdinaryDiffEq.jl"
+      subdir: "lib/DiffEqBase"
+      group: "Core"
     secrets: "inherit"
 ```
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -482,9 +482,13 @@ end
     @test occursin("joinpath(\"downstream\", ENV[\"DOWNSTREAM_SUBDIR\"])", txt)
     @test occursin("Pkg.activate(downstream_project)", txt)
     @test occursin("isfile(joinpath(downstream_project, \"Project.toml\"))", txt)
+    @test occursin("UPSTREAM_SUBDIRS: \${{ inputs.upstream-subdirs }}", txt)
+    @test occursin("split(ENV[\"UPSTREAM_SUBDIRS\"], ',')", txt)
+    @test occursin("isfile(joinpath(project, \"Project.toml\"))", txt)
+    @test occursin("Pkg.develop(map(project -> PackageSpec(path=project), upstream_projects))", txt)
 
     activate_at = findfirst("Pkg.activate(downstream_project)", txt)
-    develop_at = findfirst("Pkg.develop(PackageSpec(path=\".\"))", txt)
+    develop_at = findfirst("Pkg.develop(map(project -> PackageSpec(path=project), upstream_projects))", txt)
     test_at = findfirst("Pkg.test", txt)
     @test activate_at !== nothing && develop_at !== nothing && test_at !== nothing
     @test first(activate_at) < first(develop_at) < first(test_at)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -475,6 +475,21 @@ end
     end
 end
 
+@testset "downstream.yml selects a monorepo package project" begin
+    txt = read(joinpath(@__DIR__, "..", ".github", "workflows", "downstream.yml"), String)
+    @test occursin("subdir:", txt)
+    @test occursin("DOWNSTREAM_SUBDIR: \${{ inputs.subdir }}", txt)
+    @test occursin("joinpath(\"downstream\", ENV[\"DOWNSTREAM_SUBDIR\"])", txt)
+    @test occursin("Pkg.activate(downstream_project)", txt)
+    @test occursin("isfile(joinpath(downstream_project, \"Project.toml\"))", txt)
+
+    activate_at = findfirst("Pkg.activate(downstream_project)", txt)
+    develop_at = findfirst("Pkg.develop(PackageSpec(path=\".\"))", txt)
+    test_at = findfirst("Pkg.test", txt)
+    @test activate_at !== nothing && develop_at !== nothing && test_at !== nothing
+    @test first(activate_at) < first(develop_at) < first(test_at)
+end
+
 # A 32-bit (x86/i686) Julia leg needs the i386 loader + C/C++ runtime installed
 # BEFORE setup-julia runs julia, or the run dies with `spawn .../x86/bin/julia
 # ENOENT`. Assert tests.yml has that install step, gates it on a 32-bit arch on


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## What changed

- Add an optional `subdir` input to select the package project inside the downstream checkout.
- Add an optional comma-separated `upstream-subdirs` input to develop one or more package projects from the calling repository.
- Validate and activate the selected downstream project before developing the selected caller projects, resolving, and running tests.
- Document both monorepo directions and add regression assertions for the workflow ordering.

## Why

The organization-wide downstream CI audit found both sides of monorepo moves:

- callers that still target an obsolete repository root instead of a registered package such as `OrdinaryDiffEq.jl/lib/DiffEqBase`;
- monorepo callers whose root package is unrelated to the downstream test, while the downstream actually consumes caller subpackages such as `BoundaryValueDiffEqMIRK` and `BoundaryValueDiffEqAscher`.

Without explicit project selection, such jobs can succeed without exercising the changed package.

## Impact

Existing callers retain both defaults and continue selecting the root project. Monorepo callers can select the relevant downstream package project, one or more relevant caller package projects, or both. Missing and empty selections fail with a specific path error.

## Checks

- `timeout 3600 julia +1.10 --startup-file=no --project=. test/runtests.jl` — passed; downstream workflow assertions 11/11.
- `timeout 3600 julia +1.12 --startup-file=no --project=. test/runtests.jl` — passed; downstream workflow assertions 11/11.
- Extracted the exact reusable-workflow Julia run block and executed it against a temporary downstream package consuming two caller subpackages. Julia 1.10 and 1.12 both developed both selected projects and passed the downstream test.
- `actionlint` — passed.
- `julia +1.12 --startup-file=no -m Runic --check .` — passed.
- `git diff --check` — passed.
- Earlier downstream-side integration: exact workflow block with `DOWNSTREAM_SUBDIR=lib/DiffEqBase GROUP=Core` and local CommonSolve developed into the selected project — exit 0; substantive DiffEqBase tests completed and `DiffEqBase tests passed`.
