### PR TITLE
Surface downstream resolver incompatibilities

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -107,20 +107,9 @@ jobs:
             error("No downstream Project.toml at $downstream_project")
           Pkg.activate(downstream_project)
           @info "Selected downstream project" downstream_project
-          try
-            # force it to use this PR's version of the package
-            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
-            Pkg.update()
-            Pkg.test(coverage=${{ inputs.coverage }})  # resolver may fail with test time deps
-          catch err
-            err isa Pkg.Resolve.ResolverError || rethrow()
-
-            # If we can't resolve that means this is incompatible by SemVer and this is fine
-            # It means we marked this as a breaking change, so we don't need to worry about
-            # Mistakenly introducing a breaking change, as we have intentionally made one
-            @info "Not compatible with this release. No problem." exception=err
-            exit(0)  # Exit immediately, as a success
-          end
+          Pkg.develop(PackageSpec(path="."))
+          Pkg.update()
+          Pkg.test(coverage=${{ inputs.coverage }})
 
       - uses: julia-actions/julia-processcoverage@v1
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -490,6 +490,13 @@ end
     @test first(activate_at) < first(develop_at) < first(test_at)
 end
 
+@testset "downstream.yml propagates resolver failures" begin
+    txt = read(joinpath(@__DIR__, "..", ".github", "workflows", "downstream.yml"), String)
+    @test !occursin("Pkg.Resolve.ResolverError", txt)
+    @test !occursin("Not compatible with this release", txt)
+    @test !occursin("exit(0)", txt)
+end
+
 # A 32-bit (x86/i686) Julia leg needs the i386 loader + C/C++ runtime installed
 # BEFORE setup-julia runs julia, or the run dies with `spawn .../x86/bin/julia
 # ENOENT`. Assert tests.yml has that install step, gates it on a 32-bit arch on


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary

- Remove the reusable downstream workflow's `ResolverError` catch that converted incompatible environments into green jobs.
- Let dependency resolution and test failures propagate normally.
- Add regression assertions that forbid the prior success-exit path.

PR #115 has merged, and the shared `v1` tag now points to its merge commit `f8bbdfe`. This branch includes that released workflow state; the remaining diff is the resolver-failure propagation change.

## Local verification

- `julia +1.12 --startup-file=no test/runtests.jl` — passed; all testsets passed, including monorepo selection 11/11 and resolver propagation 3/3.
- `python3 -m unittest discover -s test -p 'test_resolve_monorepo_tagbot.py' -v` — 9/9 passed.
- Executed the exact YAML run block against two local path packages with mutually incompatible `Compat` requirements. A real `Pkg.Resolve.ResolverError` propagated on Julia 1.10 and 1.12.
- `actionlint -color` — passed.
- `julia +1.12 --startup-file=no -m Runic --check .` — passed.
- `git diff --check` — passed.

## Default-branch runtime evidence

The latest conventional downstream-workflow run census covered 193 jobs across 30 repositories. Of 186 downloadable logs, 58 concluded success after executing the compatibility catch and emitted zero test summaries. All 58 are listed in the audit record at ChrisRackauckas/InternalJunk#70. A post-release NonlinearSolve rerun independently reproduced the same behavior in all seven matrix rows.