### PR TITLE
ci: remove invalid reusable documentation permissions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,15 +56,6 @@ on:
         required: false
         type: boolean
 
-# `deploydocs` pushes to gh-pages via GITHUB_TOKEN (when no DOCUMENTER_KEY), which
-# needs `contents: write`. Set it here in the reusable so consumer caller jobs don't
-# each have to grant it (the prior per-repo permissions blocks dropped in the CI
-# centralization migration were the symptom; this is the fix at the source).
-permissions:
-  actions: write
-  contents: write
-  statuses: write
-
 jobs:
   tests:
     name: "Build and Deploy Documentation"


### PR DESCRIPTION
Ignore until reviewed by @ChrisRackauckas.

Removes permissions from the reusable documentation workflow. GitHub does not allow a called workflow to elevate permissions beyond its caller; the previous declaration causes workflow validation to fail before jobs start.

Validated locally with `actionlint .github/workflows/documentation.yml` and `git diff --check`.