### PR TITLE
ci: cache hosted reusable test jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -173,8 +173,9 @@ jobs:
         # Skip caching on self-hosted runners: demeter has a persistent, already
         # warm depot (20-29GB), so the cache always MISSES and the post-job save
         # tar-uploads 20-29GB at ~7MB/s (+30-62 min/job). Only useful on
-        # GitHub-hosted/ephemeral runners (empty `runner` and not `self-hosted`).
-        if: "${{ inputs.cache && inputs.runner == '' && !inputs.self-hosted }}"
+        # GitHub-hosted/ephemeral runners. `inputs.runner` is also populated for
+        # ordinary grouped-test legs, so it cannot identify the allocated runner.
+        if: "${{ inputs.cache && runner.environment == 'github-hosted' }}"
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -511,6 +511,7 @@ end
     @test occursin("dpkg --add-architecture i386", txt)
     @test occursin("inputs.julia-arch == 'x86'", txt)
     @test occursin("runner.os == 'Linux'", txt)
+    @test occursin("runner.environment == 'github-hosted'", txt)
     # Order: the i386 install must come before the setup-julia invocation.
     i386_at = findfirst("libc6:i386", txt)
     setup_at = findfirst("julia-actions/setup-julia", txt)


### PR DESCRIPTION
Fix the reusable test workflow so `cache: true` applies to GitHub-hosted grouped-test legs.

The prior condition treated every non-empty matrix runner label as self-hosted and skipped the cache, including `ubuntu-latest`. The runner environment is authoritative after allocation.

Local validation: `julia +1.12 test/runtests.jl` passes.

Ignore until reviewed by @ChrisRackauckas.