### PR TITLE
ci: add continue-on-error input to reusable downgrade workflow

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -58,10 +58,15 @@ on:
         default: ""
         required: false
         type: string
+      continue-on-error:
+        description: "Prevent the workflow run from failing if/when the job fails"
+        required: false
+        type: boolean
 
 jobs:
   downgrade:
     name: "Downgrade Tests${{ inputs.group != '' && format(' - {0}', inputs.group) || '' }}"
+    continue-on-error: ${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}
     # apt-packages / container legs need passwordless sudo / docker, absent on
     # the SciML self-hosted demeter*/arctic* pool (which squats only the
     # `ubuntu-latest` label, not `ubuntu-24.04`). Pin `ubuntu-24.04` to force


### PR DESCRIPTION
## Motivation

`downgrade.yml` is the only reusable test workflow here without a `continue-on-error` input — `tests.yml`, `grouped-tests.yml`, and `downstream.yml` all expose one. Callers cannot work around this: a job that invokes a reusable workflow passes everything through `with:`, so there is no caller-side way to mark the job an allowed failure.

The concrete need is SciMLBase: `SciMLBaseEnzymeExt` requires `EnzymeRules.inactive_kwarg`, which exists only in Enzyme 0.13.100+ but is not yet public API upstream, so raising the compat floor to it would just trade a downgrade failure for a dependency on unsupported API (SciML/SciMLBase.jl#1457, upstream fix in EnzymeAD/Enzyme.jl#3428). Until that lands there is no floor that is both resolvable and policy-compliant, so the job needs to be non-blocking.

## Changes

- Add a `continue-on-error` boolean input to `downgrade.yml`, applied to the `downgrade` job as `${{ inputs.continue-on-error || inputs.julia-version == 'nightly' }}`. Description and expression mirror `tests.yml` and `downstream.yml` exactly, including the nightly clause.

Default is unset (falsey), so every existing caller keeps failing on downgrade errors as before.

## Testing

`actionlint` clean, and verified end-to-end on a temporary branch of the fork with a caller workflow invoking this `downgrade.yml` in a repo with no Julia project, so the inner job is guaranteed to fail:

| caller passes | inner job conclusion | overall run conclusion |
|---|---|---|
| `continue-on-error: true` | `failure` | **`success`** |
| `continue-on-error: false` | `failure` | **`failure`** |

That is the intended allowed-failure semantics, and the control run confirms the new input is what drives it rather than something else swallowing the failure. Both temporary branches have been deleted.

Note for whoever merges: callers pin `@v1`, so the `v1` tag needs to move before SciMLBase's side of this can take effect.

Opened as a draft; should be ignored until reviewed by @ChrisRackauckas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eUfG5RgLbbZY4LRawwRG9
