### PR TITLE
feat: add auto-precompile input to the reusable test workflows

### DIFF
--- a/.github/workflows/grouped-tests.yml
+++ b/.github/workflows/grouped-tests.yml
@@ -74,6 +74,11 @@ on:
         default: false
         required: false
         type: boolean
+      auto-precompile:
+        description: "Value of JULIA_PKG_PRECOMPILE_AUTO for each test job (true -> 1, false -> 0). Set false for packages whose dependency tree OOMs the runner during Pkg's eager parallel precompilation."
+        default: true
+        required: false
+        type: boolean
 
 jobs:
   detect:
@@ -123,4 +128,5 @@ jobs:
       apt-packages: "${{ inputs.apt-packages }}"
       container: "${{ inputs.container }}"
       cache: ${{ inputs.cache }}
+      auto-precompile: ${{ inputs.auto-precompile }}
     secrets: "inherit"

--- a/.github/workflows/sublibrary-project-tests.yml
+++ b/.github/workflows/sublibrary-project-tests.yml
@@ -66,6 +66,11 @@ on:
         default: false
         required: false
         type: boolean
+      auto-precompile:
+        description: "Value of JULIA_PKG_PRECOMPILE_AUTO for each sublibrary test job (true -> 1, false -> 0). Set false for sublibraries whose dependency tree OOMs the runner during Pkg's eager parallel precompilation."
+        default: true
+        required: false
+        type: boolean
 
 jobs:
   detect:
@@ -163,6 +168,7 @@ jobs:
       coverage: ${{ inputs.coverage }}
       coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
       cache: ${{ inputs.cache }}
+      auto-precompile: ${{ inputs.auto-precompile }}
     secrets: "inherit"
 
   test-2:
@@ -187,6 +193,7 @@ jobs:
       coverage: ${{ inputs.coverage }}
       coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
       cache: ${{ inputs.cache }}
+      auto-precompile: ${{ inputs.auto-precompile }}
     secrets: "inherit"
 
   test-3:
@@ -211,6 +218,7 @@ jobs:
       coverage: ${{ inputs.coverage }}
       coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
       cache: ${{ inputs.cache }}
+      auto-precompile: ${{ inputs.auto-precompile }}
     secrets: "inherit"
 
   test-4:
@@ -235,4 +243,5 @@ jobs:
       coverage: ${{ inputs.coverage }}
       coverage-directories: "${{ matrix.project }}/src,${{ matrix.project }}/ext"
       cache: ${{ inputs.cache }}
+      auto-precompile: ${{ inputs.auto-precompile }}
     secrets: "inherit"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,6 +106,11 @@ on:
         default: false
         required: false
         type: boolean
+      auto-precompile:
+        description: "Value of JULIA_PKG_PRECOMPILE_AUTO for the whole job (true -> 1, false -> 0). Set false for packages whose dependency tree OOMs the runner during Pkg's eager parallel precompilation."
+        default: true
+        required: false
+        type: boolean
       dotgithub-ref:
         description: "Ref of SciML/.github to source the develop-sources helper script from"
         default: "v1"
@@ -126,6 +131,11 @@ jobs:
     runs-on: ${{ (inputs.apt-packages != '' || inputs.container != '') && fromJSON('["ubuntu-24.04"]') || (inputs.runner != '' && fromJson(inputs.runner) || (inputs.self-hosted && 'self-hosted' || inputs.os)) }}
     container: ${{ inputs.container }}
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    env:
+      # Job-level so it covers buildpkg (instantiate/build) as well as the test
+      # run. A caller cannot set this at its own call site: a job that uses a
+      # reusable workflow may not carry an `env:` map, so it has to be an input.
+      JULIA_PKG_PRECOMPILE_AUTO: "${{ inputs.auto-precompile && '1' || '0' }}"
     steps:
       - uses: actions/checkout@v7
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -600,3 +600,30 @@ end
     root = make_sources_fixture()
     @test isempty(collect_source_paths(joinpath(root, "Leaf")))
 end
+
+@testset "auto-precompile input is plumbed to JULIA_PKG_PRECOMPILE_AUTO" begin
+    wf(p) = read(joinpath(@__DIR__, "..", ".github", "workflows", p), String)
+
+    tests = wf("tests.yml")
+    # Declared as a boolean input, defaulting to Pkg's normal eager behavior.
+    @test occursin("auto-precompile:", tests)
+    # Job-level (not step-level) so buildpkg's instantiate/build is covered too.
+    precompile_at = findfirst("JULIA_PKG_PRECOMPILE_AUTO", tests)
+    steps_at = findfirst("\n    steps:", tests)
+    @test precompile_at !== nothing && steps_at !== nothing
+    @test first(precompile_at) < first(steps_at)
+    @test occursin("JULIA_PKG_PRECOMPILE_AUTO: \"\${{ inputs.auto-precompile && '1' || '0' }}\"", tests)
+
+    # Both fan-out workflows expose the input and forward it, or a caller has no
+    # way to set it: a job that `uses:` a reusable workflow may not carry `env:`.
+    for p in ("grouped-tests.yml", "sublibrary-project-tests.yml")
+        txt = wf(p)
+        @test occursin("auto-precompile:", txt)
+        @test occursin("auto-precompile: \${{ inputs.auto-precompile }}", txt)
+    end
+
+    # sublibrary-project-tests fans out over four shards; every one must forward
+    # it, otherwise the setting silently applies to only part of the matrix.
+    subs = wf("sublibrary-project-tests.yml")
+    @test count("auto-precompile: \${{ inputs.auto-precompile }}", subs) == 4
+end


### PR DESCRIPTION
> [!NOTE]
> Draft — please ignore until reviewed by @ChrisRackauckas.

## Problem

A job that calls a reusable workflow with `uses:` may not carry an `env:` map. GitHub's schema allows only `name`, `uses`, `with`, `secrets`, `needs`, `if`, and `permissions` there. Adding `env:` doesn't just get ignored — it makes the whole workflow file invalid, so GitHub creates **zero** jobs for it and reports a bare startup failure.

That is exactly what happened in https://github.com/SciML/ModelingToolkit.jl/pull/4867, which tried to set `JULIA_PKG_PRECOMPILE_AUTO: "0"` at the call sites of `grouped-tests.yml` and `sublibrary-project-tests.yml`:

```
$ actionlint .github/workflows/Tests.yml .github/workflows/SublibraryCI.yml
.github/workflows/Tests.yml:30:5: when a reusable workflow is called with "uses", "env" is not available.
  only following keys are allowed: "name", "uses", "with", "secrets", "needs", "if", and "permissions" in job "tests" [syntax-check]
.github/workflows/SublibraryCI.yml:27:5: ... in job "sublibrary-ci" [syntax-check]
```

The result on that PR: no `Tests` and no `Sublibrary CI` checks at all, just two runs listed by file path with no jobs (["This run likely failed because of a workflow file issue"](https://github.com/SciML/ModelingToolkit.jl/actions/runs/30901431064)). There is currently no supported way for a consumer to control this env var.

## Change

Expose it as an input instead.

- **`tests.yml`** — new boolean input `auto-precompile` (default `true`), applied as a **job-level** `env:` so it covers `julia-buildpkg`'s instantiate/build as well as the `julia-runtest` step:
  ```yaml
  env:
    JULIA_PKG_PRECOMPILE_AUTO: "${{ inputs.auto-precompile && '1' || '0' }}"
  ```
- **`grouped-tests.yml`** — same input, forwarded to the root-matrix test job.
- **`sublibrary-project-tests.yml`** — same input, forwarded from all four shard jobs.

Default `true` is Pkg's normal behavior, so this is a no-op for every existing consumer. Setting `auto-precompile: false` defers compilation to load time in the test process, which is the escape hatch for dependency trees that OOM the 4vCPU/8GB runners during Pkg's eager parallel precompilation.

## Testing

```
$ actionlint .github/workflows/*.yml
(exit 0)

$ julia --project=. test/runtests.jl
...
Test Summary:                                                 | Pass  Total  Time
auto-precompile input is plumbed to JULIA_PKG_PRECOMPILE_AUTO |    9      9  0.0s
```

Full suite passes. The new testset asserts the input exists on all three workflows, that `tests.yml` sets the env var *above* `steps:` (job-level, not step-level), and that all four shards forward it. Verified non-vacuous by deleting one shard's forward:

```
Expression: count("auto-precompile: \${{ inputs.auto-precompile }}", subs) == 4
 Evaluated: 3 == 4
```

Runic-clean on `test/runtests.jl`.

## Follow-up

`v1` only moves when a `vX.Y.Z` release tag is pushed (`major-version-tag.yml`), so consumers on `@v1` won't see this input until a release is cut. The ModelingToolkit side is being fixed in two steps: drop the invalid `env:` blocks now to unblock CI, then pass `auto-precompile: false` once `v1` carries this.

## Alternative considered

A generic `env-vars` multiline input piped into `$GITHUB_ENV` would cover future vars without another PR here, but it's a broader surface for a narrow need. Happy to switch if you'd prefer that shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0172My4BE5TgvJmuYxkBuvxU
