### PR TITLE
Restore project metadata before downgrade QA

### DIFF
--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -146,10 +146,7 @@ jobs:
         if: "${{ inputs.project == '@.' }}"
         shell: bash
         run: |
-          # A combined downgrade resolution writes the same merged manifest to
-          # every project directory. Pkg.test from the root project must resolve
-          # its test project against the root manifest, not merge two fixed
-          # manifests with potentially incompatible project metadata.
+          # Keep Pkg.test from merging two fixed manifests after combined resolution.
           save_dir="$RUNNER_TEMP/sciml-downgrade-secondary-manifests"
           mkdir -p "$save_dir"
           IFS=',' read -ra dirs <<< "${{ inputs.projects }}"

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -122,6 +122,19 @@ jobs:
           echo "Effective downgrade skip: $effective"
           echo "EFFECTIVE_SKIP=$effective" >> "$GITHUB_ENV"
 
+      - name: "Save project metadata for QA"
+        if: "${{ inputs.group == 'QA' }}"
+        shell: bash
+        run: |
+          save_dir="$RUNNER_TEMP/sciml-downgrade-original-projects"
+          mkdir -p "$save_dir"
+          IFS=',' read -ra dirs <<< "${{ inputs.projects }}"
+          for dir in "${dirs[@]}"; do
+              dir="$(echo "$dir" | xargs)"
+              [ -f "$dir/Project.toml" ] || continue
+              cp --parents "$dir/Project.toml" "$save_dir"
+          done
+
       - uses: julia-actions/julia-downgrade-compat@v2
         with:
           skip: "${{ env.EFFECTIVE_SKIP }}"
@@ -138,6 +151,16 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
         with:
           project: "${{ inputs.project }}"
+
+      - name: "Restore project metadata before QA"
+        if: "${{ inputs.group == 'QA' }}"
+        shell: bash
+        run: |
+          save_dir="$RUNNER_TEMP/sciml-downgrade-original-projects"
+          while IFS= read -r -d '' saved; do
+              relative="${saved#"$save_dir/"}"
+              cp "$saved" "$relative"
+          done < <(find "$save_dir" -name Project.toml -print0)
 
       - uses: julia-actions/julia-runtest@v1
         with:

--- a/.github/workflows/downgrade.yml
+++ b/.github/workflows/downgrade.yml
@@ -142,6 +142,27 @@ jobs:
           mode: "${{ inputs.mode != '' && inputs.mode || 'deps' }}"
           no_promote: "${{ inputs.no_promote }}"
 
+      - name: "Remove secondary manifests before root test"
+        if: "${{ inputs.project == '@.' }}"
+        shell: bash
+        run: |
+          # A combined downgrade resolution writes the same merged manifest to
+          # every project directory. Pkg.test from the root project must resolve
+          # its test project against the root manifest, not merge two fixed
+          # manifests with potentially incompatible project metadata.
+          save_dir="$RUNNER_TEMP/sciml-downgrade-secondary-manifests"
+          mkdir -p "$save_dir"
+          IFS=',' read -ra dirs <<< "${{ inputs.projects }}"
+          for dir in "${dirs[@]}"; do
+              dir="$(echo "$dir" | xargs)"
+              [ -n "$dir" ] || continue
+              [ "$dir" = "." ] && continue
+              manifest="$dir/Manifest.toml"
+              [ -f "$manifest" ] || continue
+              mkdir -p "$save_dir/$dir"
+              mv "$manifest" "$save_dir/$manifest"
+          done
+
       - name: "Install system packages"
         if: "${{ inputs.apt-packages != '' && runner.os == 'Linux' }}"
         run: |


### PR DESCRIPTION
DowngradeCI promotes old-style `[targets].test` dependencies into `[deps]`, so Aqua sees temporary test-only packages as stale runtime dependencies during QA. For QA jobs, save every project listed in `projects` before downgrade and restore its original `Project.toml` after the downgraded build; the minimum manifest remains in place, so functional groups still test the floor-resolved environment while QA inspects the package’s real dependency tables.

When a root test uses a secondary project such as `test`, combined downgrade resolution also writes a fixed manifest there. The workflow now moves those secondary manifests aside before root `Pkg.test`, preventing Julia from trying to merge two fixed environments.

Verification:

- `git diff --check`, `actionlint`, and `typos .github/workflows/downgrade.yml` passed.
- The temporary `.,test` save/restore and secondary-manifest simulation passed.
- Local LHLFactorization QA with restored project metadata passed: 19/19 tests.

No public API changes and no deprecation path is applicable. Please ignore this PR until it has been reviewed by @ChrisRackauckas.