### PR TITLE
Support monorepo package globs in downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -27,7 +27,7 @@ on:
         required: false
         type: string
       upstream-subdirs:
-        description: "Comma-separated package paths in the calling repository to develop"
+        description: "Comma-separated package paths or directory globs ending in /* in the calling repository to develop"
         default: "."
         required: false
         type: string
@@ -113,9 +113,22 @@ jobs:
             error("No downstream Project.toml at $downstream_project")
           Pkg.activate(downstream_project)
           @info "Selected downstream project" downstream_project
-          upstream_projects = filter(!isempty, strip.(split(ENV["UPSTREAM_SUBDIRS"], ',')))
+          upstream_specs = filter(!isempty, strip.(split(ENV["UPSTREAM_SUBDIRS"], ',')))
+          upstream_projects = String[]
+          for spec in upstream_specs
+            if endswith(spec, "/*")
+              matches = filter(
+                project -> isfile(joinpath(project, "Project.toml")),
+                readdir(dirname(spec); join=true),
+              )
+              isempty(matches) && error("No upstream package projects matched $spec")
+              append!(upstream_projects, matches)
+            else
+              push!(upstream_projects, spec)
+            end
+          end
           isempty(upstream_projects) && error("No upstream package projects selected")
-          upstream_projects = normpath.(upstream_projects)
+          upstream_projects = unique(normpath.(upstream_projects))
           for project in upstream_projects
             isfile(joinpath(project, "Project.toml")) ||
               error("No upstream Project.toml at $project")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -486,6 +486,8 @@ end
     @test occursin("split(ENV[\"UPSTREAM_SUBDIRS\"], ',')", txt)
     @test occursin("isfile(joinpath(project, \"Project.toml\"))", txt)
     @test occursin("Pkg.develop(map(project -> PackageSpec(path=project), upstream_projects))", txt)
+    @test occursin("endswith(spec, \"/*\")", txt)
+    @test occursin("readdir(dirname(spec); join=true)", txt)
 
     activate_at = findfirst("Pkg.activate(downstream_project)", txt)
     develop_at = findfirst("Pkg.develop(map(project -> PackageSpec(path=project), upstream_projects))", txt)


### PR DESCRIPTION
## What changed and why

The reusable downstream workflow already defaults to Julia `1`, but callers could only enumerate upstream package directories individually. This adds a trailing `/*` form to `upstream-subdirs` and develops the immediate child directories that contain a `Project.toml`.

OrdinaryDiffEq can use `.,lib/*` when it migrates its bespoke Julia-1.10 downstream job to this shared workflow. That addresses the ProbNumDiffEq resolver failure at the workflow layer requested in https://github.com/SciML/OrdinaryDiffEq.jl/pull/4320.

Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Verification

Failing before the workflow change, with the new assertions applied:

```text
julia +1.12 --startup-file=no test/runtests.jl
downstream.yml selects a monorepo package project | 12 pass, 2 fail, 14 total
missing: endswith(spec, "/*")
missing: readdir(dirname(spec); join=true)
```

Passing after:

```text
julia +1.12 --startup-file=no test/runtests.jl
downstream.yml selects a monorepo package project | 13 pass, 13 total
EXIT=0
```

An isolated fixture containing a root project, `lib/A`, `lib/B`, and a non-package `lib/not-a-package` resolved to:

```text
[".", "lib/A", "lib/B"]
```

Also passed:

```text
actionlint .github/workflows/downstream.yml
typos .github/workflows/downstream.yml test/runtests.jl
git diff --check
julia +1.12 --project=<Runic environment> -e 'using Runic; exit(Runic.main(["--check", "--diff", "test/runtests.jl"]))'
```

## Not verified

I did not run an end-to-end reusable-workflow invocation on GitHub Actions locally. The follow-up OrdinaryDiffEq migration should remain blocked on this prerequisite.
